### PR TITLE
Change order of build to start with solvers

### DIFF
--- a/docker/build-extensions/build-windows.ps1
+++ b/docker/build-extensions/build-windows.ps1
@@ -46,7 +46,7 @@ catch{
   echo "Solvers were not built."
 }
 docker rm ${flavor}_build_tmp
-#docker rmi ${flavor}_build_itmp
+docker rmi ${flavor}_build_itmp
 cp *.tar.gz ../tarballs/
 Remove-Item *.tar.gz
 cd ..

--- a/docker/build-extensions/centos6/Dockerfile
+++ b/docker/build-extensions/centos6/Dockerfile
@@ -16,5 +16,5 @@ RUN cd repo; \
 ##
 RUN pwd; cd repo/idaes-ext; \
     export BOOST_HEADER=/repo/boost_1_61_0; \
-    bash scripts/compile_libs.sh centos6; \
-    bash scripts/compile_solvers.sh centos6
+    bash scripts/compile_solvers.sh centos6; \
+    bash scripts/compile_libs.sh centos6

--- a/docker/build-extensions/centos7/Dockerfile
+++ b/docker/build-extensions/centos7/Dockerfile
@@ -15,5 +15,5 @@ RUN cd repo; \
 # Build all the things
 ##
 RUN pwd; cd repo/idaes-ext; \
-    bash scripts/compile_libs.sh centos7; \
-    bash scripts/compile_solvers.sh centos7
+    bash scripts/compile_solvers.sh centos7; \
+    bash scripts/compile_libs.sh centos7

--- a/docker/build-extensions/centos8/Dockerfile
+++ b/docker/build-extensions/centos8/Dockerfile
@@ -15,5 +15,5 @@ RUN cd repo; \
 # Build all the things
 ##
 RUN pwd; cd repo/idaes-ext; \
-    bash scripts/compile_libs.sh centos8; \
-    bash scripts/compile_solvers.sh centos8
+    bash scripts/compile_solvers.sh centos8; \
+    bash scripts/compile_libs.sh centos8

--- a/docker/build-extensions/ubuntu1804/Dockerfile
+++ b/docker/build-extensions/ubuntu1804/Dockerfile
@@ -15,5 +15,5 @@ RUN cd repo; \
 # Build all the things
 ##
 RUN pwd; cd repo/idaes-ext; \
-    bash scripts/compile_libs.sh ubuntu1804; \
-    bash scripts/compile_solvers.sh ubuntu1804
+    bash scripts/compile_solvers.sh ubuntu1804; \
+    bash scripts/compile_libs.sh ubuntu1804

--- a/docker/build-extensions/ubuntu1910/Dockerfile
+++ b/docker/build-extensions/ubuntu1910/Dockerfile
@@ -15,5 +15,5 @@ RUN cd repo; \
 # Build all the things
 ##
 RUN pwd; cd repo/idaes-ext; \
-    bash scripts/compile_libs.sh ubuntu1910; \
-    bash scripts/compile_solvers.sh ubuntu1910
+    bash scripts/compile_solvers.sh ubuntu1910; \
+    bash scripts/compile_libs.sh ubuntu1910

--- a/docker/build-extensions/ubuntu2004/Dockerfile
+++ b/docker/build-extensions/ubuntu2004/Dockerfile
@@ -15,5 +15,5 @@ RUN cd repo; \
 # Build all the things
 ##
 RUN pwd; cd repo/idaes-ext; \
-    bash scripts/compile_libs.sh ubuntu2004; \
-    bash scripts/compile_solvers.sh ubuntu2004
+    bash scripts/compile_solvers.sh ubuntu2004; \
+    bash scripts/compile_libs.sh ubuntu2004

--- a/docker/build-extensions/windows/Dockerfile
+++ b/docker/build-extensions/windows/Dockerfile
@@ -7,5 +7,5 @@ SHELL ["C:\\msys64\\usr\\bin\\bash.exe", "-l", "-c"]
 ENV MSYSTEM MINGW64
 
 COPY ./extras/ c:/repo/
-RUN 'export PATH=/c/msys64/mingw64/bin:$PATH && cd /c/repo/ && git clone $repo && cd idaes-ext && git checkout $branch && sh scripts/compile_libs.sh windows';
-RUN 'export PATH=/c/msys64/mingw64/bin:$PATH && cd /c/repo/idaes-ext && sh scripts/compile_solvers.sh windows';
+RUN 'export PATH=/c/msys64/mingw64/bin:$PATH && cd /c/repo/ && git clone $repo && cd idaes-ext && git checkout $branch && sh scripts/compile_solvers.sh windows';
+RUN 'export PATH=/c/msys64/mingw64/bin:$PATH && cd /c/repo/idaes-ext && sh scripts/compile_libs.sh windows';


### PR DESCRIPTION
Start with solver build, so I can use that copy of ASL from that to compile user defined AMPL functions.