### PR TITLE
Try to fix centos 7 and 8 builds

### DIFF
--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -101,7 +101,7 @@ echo "#########################################################################"
 echo "# Thirdparty/Mumps                                                      #"
 echo "#########################################################################"
 cd ThirdParty/Mumps
-./configure --disable-shared --enable-static --with-metis --prefix=$IDAES_EXT/coinbrew/dist
+./configure --disable-shared --enable-static --with-metis --prefix=$IDAES_EXT/coinbrew/dist CPPFLAGS="-fPIC"
 make
 make install
 cd $IDAES_EXT/coinbrew


### PR DESCRIPTION
On CentOS 7 and 8 I see an error linking mumps like:

```/usr/bin/ld: /repo/idaes-ext/coinbrew/dist/lib/libcoinmumps.a(dmumps_part3.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC``` 

This is trying to fix it.