### PR TITLE
Fix Mumps/HSL linking errors on CentOS 7 and 8

### DIFF
--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -92,7 +92,7 @@ echo "#########################################################################"
 echo "# Thirdparty/HSL                                                        #"
 echo "#########################################################################"
 cd ThirdParty/HSL
-./configure --disable-shared --enable-static --with-metis --prefix=$IDAES_EXT/coinbrew/dist
+./configure --disable-shared --enable-static --with-metis --prefix=$IDAES_EXT/coinbrew/dist FFLAGS="-fPIC" CFLAGS="-fPIC" CXXFLAGS="-fPIC"
 make
 make install
 cd $IDAES_EXT/coinbrew
@@ -101,7 +101,7 @@ echo "#########################################################################"
 echo "# Thirdparty/Mumps                                                      #"
 echo "#########################################################################"
 cd ThirdParty/Mumps
-./configure --disable-shared --enable-static --with-metis --prefix=$IDAES_EXT/coinbrew/dist CPPFLAGS="-fPIC"
+./configure --disable-shared --enable-static --with-metis --prefix=$IDAES_EXT/coinbrew/dist FFLAGS="-fPIC" CFLAGS="-fPIC" CXXFLAGS="-fPIC"
 make
 make install
 cd $IDAES_EXT/coinbrew


### PR DESCRIPTION
This should fix the linking error for MUMPS on CentOS 7 and 8.  Tested it this time, and seems to work.