### PR TITLE
Fix mysterious linking errors on some platforms

### DIFF
--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -182,7 +182,7 @@ echo "#########################################################################"
 echo "# Cbc                                                                   #"
 echo "#########################################################################"
 cd Cbc
-./configure --disable-shared --enable-static --prefix=$IDAES_EXT/coinbrew/dist
+./configure --disable-shared --enable-static --prefix=$IDAES_EXT/coinbrew/dist LDFLAGS=-fopenmp
 make
 make install
 cd $IDAES_EXT/coinbrew
@@ -207,7 +207,7 @@ echo "#########################################################################"
 echo "# Couenne                                                               #"
 echo "#########################################################################"
 cd Couenne
-./configure --disable-shared --enable-static --prefix=$IDAES_EXT/coinbrew/dist
+./configure --disable-shared --enable-static --prefix=$IDAES_EXT/coinbrew/dist LDFLAGS=-fopenmp
 make
 make install
 cd $IDAES_EXT/coinbrew
@@ -215,11 +215,11 @@ cd $IDAES_EXT/coinbrew
 echo "#########################################################################"
 echo "# Ipopt Shared Libraries                                                #"
 echo "#########################################################################"
-#cd Ipopt
-#./configure --enable-shared --without-asl --prefix=$IDAES_EXT/coinbrew/dist
-#make
-#make install
-#cd $IDAES_EXT/coinbrew
+cd Ipopt
+./configure --enable-shared --without-asl --prefix=$IDAES_EXT/coinbrew/dist
+make
+make install
+cd $IDAES_EXT/coinbrew
 
 # Copy files
 cd $IDAES_EXT


### PR DESCRIPTION
This explicitly add the flag to link OpenMP. It should be linked anyway, but for some reason Bonmin and Couenne were having trouble on Windows and CentOS 6.  Other platforms don't seen to need the added flag, but it shouldn't hurt.