### PR TITLE
Remove temporary version file

### DIFF
--- a/scripts/compile_libs.sh
+++ b/scripts/compile_libs.sh
@@ -29,6 +29,7 @@ cp ../version.txt ./version_lib.txt
 sed s/"(DATE)"/`date +%Y%m%d-%H%M`/g version_lib.txt > tmp
 sed s/"(PLAT)"/${osname}/g tmp > tmp2
 mv tmp2 version_lib.txt
+rm tmp
 
 # here you pack files
 tar -czvf idaes-lib-${osname}-64.tar.gz *

--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -249,6 +249,7 @@ cp ../version.txt ./version_solvers.txt
 sed s/"(DATE)"/`date +%Y%m%d-%H%M`/g version_solvers.txt > tmp
 sed s/"(PLAT)"/${osname}/g tmp > tmp2
 mv tmp2 version_solvers.txt
+rm tmp
 
 if [ ${osname} = "windows" ]
 then


### PR DESCRIPTION
This fixes https://github.com/IDAES/idaes-ext/issues/94.  The "tmp" files should be gone in the next patch release.  I've also fixed a problem were the shared ipopt libraries were missing on Windows.  I'm building up issues for the next patch release already.