### PR TITLE
Add petsc-ampl solver

### DIFF
--- a/docker/build-platform/centos7/Dockerfile
+++ b/docker/build-platform/centos7/Dockerfile
@@ -14,8 +14,9 @@ RUN cd repo; \
     wget https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-3.15.0.tar.gz; \
     tar -zxvf petsc-3.15.0.tar.gz; \
     mv petsc-3.15.0 petsc; \
-    mkdir petsc-dist; \
-    cd petsc; \
-    ./configure --with-debug=0 --with-shared=0 --with-fortran-bindings=0 --download-mpich --download-mumps --download-hypre --download-sundials --download-superlu --download-scalapack --download-metis --download-parmetis --download-ptscotch --download-ml --download-suitesparse --download-strumpack --prefix=/repo/petsc-dist; \
+    mkdir petsc-dist
+
+RUN cd repo/petsc; \
+    ./configure CPPFLAGS="-D_POSIX_C_SOURCE=199309L" --with-debug=0 --with-shared=0 --with-fortran-bindings=0 --download-mpich --download-mumps --download-hypre --download-sundials --download-superlu --download-scalapack --download-metis --download-parmetis --download-ptscotch --download-ml --download-suitesparse --download-strumpack --prefix=/repo/petsc-dist; \
     make;\
     make install;\

--- a/docker/build-platform/centos7/Dockerfile
+++ b/docker/build-platform/centos7/Dockerfile
@@ -2,9 +2,20 @@ FROM centos:centos7
 MAINTAINER The CentOS Project <cloud-ops@centos.org>
 
 RUN yum -y update; yum clean all
-RUN yum -y install git make gcc gcc-c++ gcc-gfortran boost-devel
+RUN yum -y install git make gcc gcc-c++ gcc-gfortran boost-devel valgrind
 RUN yum -y install wget unzip patch which file lapack-devel blas-devel
+RUN yum -y install flex bison
 RUN yum -y install epel-release
 RUN yum -y install cmake3
 RUN ln -s /usr/bin/cmake3 /usr/bin/cmake
 RUN mkdir repo
+
+RUN cd repo; \
+    wget https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-3.15.0.tar.gz; \
+    tar -zxvf petsc-3.15.0.tar.gz; \
+    mv petsc-3.15.0 petsc; \
+    mkdir petsc-dist; \
+    cd petsc; \
+    ./configure --with-debug=0 --with-shared=0 --with-fortran-bindings=0 --download-mpich --download-mumps --download-hypre --download-sundials --download-superlu --download-scalapack --download-metis --download-parmetis --download-ptscotch --download-ml --download-suitesparse --download-strumpack --prefix=/repo/petsc-dist; \
+    make;\
+    make install;\

--- a/docker/build-platform/centos8/Dockerfile
+++ b/docker/build-platform/centos8/Dockerfile
@@ -8,6 +8,7 @@ RUN yum -y install flex bison
 RUN yum -y install dnf-plugins-core
 RUN yum config-manager --set-enabled powertools
 RUN dnf --enablerepo=powertools -y install lapack-devel
+RUN dnf -y install python3
 RUN mkdir repo
 
 RUN cd repo; \

--- a/docker/build-platform/centos8/Dockerfile
+++ b/docker/build-platform/centos8/Dockerfile
@@ -3,8 +3,19 @@ MAINTAINER The CentOS Project <cloud-ops@centos.org>
 
 RUN yum -y update; yum clean all
 RUN yum -y install git make gcc gcc-c++ gcc-gfortran boost-devel cmake
-RUN yum -y install wget unzip patch which file
+RUN yum -y install wget unzip patch which file valgrind
+RUN yum -y install flex bison
 RUN yum -y install dnf-plugins-core
 RUN yum config-manager --set-enabled PowerTools
 RUN dnf --enablerepo=PowerTools -y install lapack-devel
 RUN mkdir repo
+
+RUN cd repo; \
+    wget https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-3.15.0.tar.gz; \
+    tar -zxvf petsc-3.15.0.tar.gz; \
+    mv petsc-3.15.0 petsc; \
+    mkdir petsc-dist; \
+    cd petsc; \
+    ./configure --with-debug=0 --with-shared=0 --with-fortran-bindings=0 --download-mpich --download-mumps --download-hypre --download-sundials --download-superlu --download-scalapack --download-metis --download-parmetis --download-ptscotch --download-ml --download-suitesparse --download-strumpack --prefix=/repo/petsc-dist; \
+    make;\
+    make install;\

--- a/docker/build-platform/centos8/Dockerfile
+++ b/docker/build-platform/centos8/Dockerfile
@@ -6,8 +6,8 @@ RUN yum -y install git make gcc gcc-c++ gcc-gfortran boost-devel cmake
 RUN yum -y install wget unzip patch which file valgrind
 RUN yum -y install flex bison
 RUN yum -y install dnf-plugins-core
-RUN yum config-manager --set-enabled PowerTools
-RUN dnf --enablerepo=PowerTools -y install lapack-devel
+RUN yum config-manager --set-enabled powertools
+RUN dnf --enablerepo=powertools -y install lapack-devel
 RUN mkdir repo
 
 RUN cd repo; \

--- a/docker/build-platform/ubuntu1804/Dockerfile
+++ b/docker/build-platform/ubuntu1804/Dockerfile
@@ -4,5 +4,16 @@ RUN apt-get -y update; \
     apt-get -y upgrade; \
     apt-get -y install ubuntu-dev-tools liblapack-dev libblas-dev unzip
 
-RUN apt-get -y install gfortran libboost-all-dev cmake
+RUN apt-get -y install gfortran libboost-all-dev cmake bison
+RUN apt-get -y install flex valgrind
 RUN mkdir repo
+
+RUN cd repo; \
+    wget https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-3.15.0.tar.gz; \
+    tar -zxvf petsc-3.15.0.tar.gz; \
+    mv petsc-3.15.0 petsc; \
+    mkdir petsc-dist; \
+    cd petsc; \
+    ./configure --with-debug=0 --with-shared=0 --with-fortran-bindings=0 --download-mpich --download-mumps --download-hypre --download-sundials --download-superlu --download-scalapack --download-metis --download-parmetis --download-ptscotch --download-ml --download-suitesparse --download-strumpack --prefix=/repo/petsc-dist; \
+    make;\
+    make install;\

--- a/docker/build-platform/ubuntu1910/Dockerfile
+++ b/docker/build-platform/ubuntu1910/Dockerfile
@@ -4,5 +4,16 @@ RUN apt-get -y update; \
     apt-get -y upgrade; \
     apt-get -y install ubuntu-dev-tools liblapack-dev libblas-dev unzip pkg-config
 
-RUN apt-get -y install gfortran libboost-all-dev cmake
+RUN apt-get -y install gfortran libboost-all-dev cmake bison
+RUN apt-get -y install flex valgrind
 RUN mkdir repo
+
+RUN cd repo; \
+    wget https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-3.15.0.tar.gz; \
+    tar -zxvf petsc-3.15.0.tar.gz; \
+    mv petsc-3.15.0 petsc; \
+    mkdir petsc-dist; \
+    cd petsc; \
+    ./configure --with-debug=0 --with-shared=0 --with-fortran-bindings=0 --download-mpich --download-mumps --download-hypre --download-sundials --download-superlu --download-scalapack --download-metis --download-parmetis --download-ptscotch --download-ml --download-suitesparse --download-strumpack --prefix=/repo/petsc-dist; \
+    make;\
+    make install;\

--- a/docker/build-platform/ubuntu2004/Dockerfile
+++ b/docker/build-platform/ubuntu2004/Dockerfile
@@ -7,5 +7,17 @@ RUN apt-get -y update; \
     apt-get -y install ubuntu-dev-tools liblapack-dev libblas-dev unzip
 
 RUN apt-get -y install gfortran libboost-all-dev cmake
-RUN apt-get -y install pkg-config
+RUN apt-get -y install pkg-config bison
+RUN apt-get -y install flex valgrind
+
 RUN mkdir repo
+
+RUN cd repo; \
+    wget https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-3.15.0.tar.gz; \
+    tar -zxvf petsc-3.15.0.tar.gz; \
+    mv petsc-3.15.0 petsc; \
+    mkdir petsc-dist; \
+    cd petsc; \
+    ./configure --with-debug=0 --with-shared=0 --with-fortran-bindings=0 --download-mpich --download-mumps --download-hypre --download-sundials --download-superlu --download-scalapack --download-metis --download-parmetis --download-ptscotch --download-ml --download-suitesparse --download-strumpack --prefix=/repo/petsc-dist; \
+    make;\
+    make install;\

--- a/petsc/Makefile
+++ b/petsc/Makefile
@@ -1,0 +1,14 @@
+ALL: petsc
+
+CFLAGS = -I${ASL_BUILD}
+
+include ${PETSC_DIR}/lib/petsc/conf/variables
+include ${PETSC_DIR}/lib/petsc/conf/rules
+
+bindir = $(prefix)/bin
+
+petsc: petsc.o fg_nl.o fg_dae.o scale.o printing.o chkopts
+	${CLINKER} -o petsc petsc.o fg_nl.o fg_dae.o scale.o printing.o $(ASL_BUILD)/amplsolver.a ${PETSC_LIB}
+
+install: petsc
+	${CP} petsc ${bindir}

--- a/petsc/README.md
+++ b/petsc/README.md
@@ -1,0 +1,45 @@
+# README
+
+This is a first pass at creating an AMPL executable for the PETSc solver library, allowing PETSc to be used with Pyomo.  This version supports the TS (time-stepping) and SNES (nonlinear) solvers; however in the future TAO (optimization) solvers and additional features may also be supported.
+
+## Building
+This will probably be reasonably accurate for Linux, Mac, and Unix, but Windows may be more difficult.  The petsc AMPL executable is built with the PETSc build system, so if you can use the PETSc documentation to build PETSc, building the solver wrapper should be easy.
+
+1. Build PETSc according the documentation: https://www.mcs.anl.gov/petsc/.
+   * The default linear solver is currently set to MUMPS so, be sure to build PETSc with MUMPS (there is a configuration option to download MUMPS).
+   * A good approach to building PETSc is to include everything that is easy to include in case you want to use it.  Here is an example configuration command.
+   ```
+   ./configure --download-cmake --download-fblaspack --download-mpich
+      --download-mumps --download-sundials --download-superlu
+      --download-scalapack --download-metis --download-parmetis
+      --download-ptscotch --download-ml --download-suitesparse
+      --download-strumpack
+   ```
+
+2. Get the ASL library from: https://ampl.com/netlib/ampl/solvers.tgz.
+  1. Extract the files.
+  2. In the directory where the source code was extracted run    ```./configure```
+  3. Go to sys._arch_ and run ```make``` (_arch_ depends on your machine).
+
+3. Set some environment variables (may want to add to .bashrc or a script if you do this regularly).
+  1. PETSC_DIR = location of PETSc source
+  2. PETSC_ARCH = subdirectory where PETSc was compiled
+  3. ASL_BUILD = directory where ASL was compiled
+4. Run ```make``` the directory where building the petsc executable. This mostly uses the PETSc build system, so this part is pretty simple.
+5. Copy the executable to a location in your execution path.
+
+## Usage
+
+The petsc executable solver will run like any other AMPL executable and can take the standard PETSc options.  The options can be set from within Pyomo.  For use with Pyomo it is easiest if the petsc executable is in your executable path.
+
+<TODO> Will fill out later, for now see examples and PETSc docs.  PETSc command line options work with the PETSc solvers. The are some additional command line arguments (see ```petsc -help```).  Command line arguments can be passed through Pyomo's solver interface.
+
+## Testing
+
+The included tl.nl file can be used to test the petsc solver. The problem is an old version of the IDAES MEA model, but that's not important. The initial values of variables in the file are the solution.  To test the solver the initial values can be perturbed before solving the problem the new solution can be compared to the old initial values to ensure the problem solved.
+
+To test the petsc executable run:
+
+petsc -s t1 -snes_monitor -perturb_test 1.1
+
+This multiplies the initial values by 1.1 and resolves.  The results shows any differences between the new and old solutions greater than 1e-6, and the values of those variables.  Depending on the value of the variables, difference of more than 1e-6 are not necessarily bad.

--- a/petsc/examples/dae_pyomo/car_example.py
+++ b/petsc/examples/dae_pyomo/car_example.py
@@ -1,0 +1,135 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+# Ampl Car Example
+#
+# Modified pyomo.dae example to remove optimization, and set up PETSc solve
+#
+# min tf
+# dxdt = 0
+# dvdt = a-R*v^2
+# x(0)=0; x(tf)=L
+# v(0)=0; v(tf)=0
+# -3<=a<=1
+
+from pyomo.environ import ConcreteModel, Param, Var, Constraint, Suffix, SolverFactory
+
+m = ConcreteModel()
+
+m.R = Param(initialize=0.001) #  Friction factor
+m.L = Param(initialize=100.0) #  Final position
+
+m.tau = Var() #ContinuousSet(bounds=(0,1)) # Unscaled time
+m.time = Var() # Scaled time
+m.x = Var(bounds=(0,m.L+50)) #Var(m.ta,bounds=(0,m.L+50))
+m.v = Var(bounds=(0,None)) #Var(m.tau,bounds=(0,None))
+m.a = Var(bounds=(-3.0,1.0),initialize=1) #Var(m.tau, bounds=(-3.0,1.0),initialize=0)
+m.tf = Var(initialize=1.0)
+m.a.fix()
+m.tf.fix()
+
+m.dtime = Var() #DerivativeVar(m.time)
+m.dx = Var() #DerivativeVar(m.x)
+m.dv = Var() #DerivativeVar(m.v)
+
+#m.obj = Objective(expr=m.tf)
+
+#def _ode1(m,i):
+#    if i == 0 :
+#        return Constraint.Skip
+#    return m.dx[i] == m.tf * m.v[i]
+#m.ode1 = Constraint(m.tau, rule=_ode1)
+m.ode1 = Constraint(expr=m.dx == m.tf * m.v)
+
+#def _ode2(m,i):
+#    if i == 0 :
+#        return Constraint.Skip
+#    return m.dv[i] == m.tf*(m.a[i] - m.R*m.v[i]**2)
+#m.ode2 = Constraint(m.tau, rule=_ode2)
+m.ode2 = Constraint(expr=m.dv == m.tf*(m.a - m.R*m.v**2))
+
+#def _ode3(m,i):
+#    if i == 0:
+#        return Constraint.Skip
+#    return m.dtime[i] == m.tf
+#m.ode3 = Constraint(m.tau, rule=_ode3)
+m.ode3 = Constraint(expr=m.dtime == m.tf)
+
+# Found a hole in the DAE solver, x isn't in the constraints so its not in the
+# nl file.  Added this constraint to force it in
+m.xdummy = Var()
+m.timedummy = Var()
+m.dummy1 = Constraint(expr=m.x == m.xdummy)
+m.dummy2 = Constraint(expr=m.time == m.timedummy)
+
+#def _init(m):
+#    yield m.x[0] == 0
+#    yield m.x[1] == m.L
+#    yield m.v[0] == 0
+#    yield m.v[1] == 0
+#    yield m.time[0] == 0
+#m.initcon = ConstraintList(rule=_init)
+
+m.x.value = 0
+m.v.value = 0
+m.time = 0
+
+#Set suffixes to show the structure of the problem
+# dae_suffix holds variable types 0=algebraic 1=differential 2=derivative
+# 3=time. dae_link associates differential variables to their derivatives
+m.dae_suffix = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
+m.dae_link = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
+m.dae_suffix[m.tau] = 3 # this labels t as the time variables (not really needed here)
+m.dae_suffix[m.time] = 1
+m.dae_suffix[m.x] = 1
+m.dae_suffix[m.v] = 1
+m.dae_suffix[m.dtime] = 2
+m.dae_suffix[m.dx] = 2
+m.dae_suffix[m.dv] = 2
+# Link the differential vars to the derivatives
+m.dae_link[m.time] = 1
+m.dae_link[m.x] = 2
+m.dae_link[m.v] = 3
+m.dae_link[m.dtime] = 1
+m.dae_link[m.dx] = 2
+m.dae_link[m.dv] = 3
+
+
+#discretizer = TransformationFactory('dae.finite_difference')
+#discretizer.apply_to(m,nfe=15,scheme='BACKWARD')
+
+#solver = SolverFactory('ipopt')
+#solver.solve(m,tee=True)
+solver = SolverFactory('petsc')
+res = solver.solve(m, tee=True,
+    options={
+        "-dae_solve":"",             #tell solver to expect dae problem
+        "-ts_monitor":"",            #show progess of TS solver
+        "-ts_max_snes_failures":40,  #max nonlin solve fails before give up
+        "-ts_max_reject":20,         #max steps to reject
+        "-ts_type":"alpha",          #ts_solver
+        "-snes_monitor":"",          #show progress on nonlinear solves
+        "-pc_type":"lu",             #direct solve MUMPS default LU fact
+        "-ksp_type":"preonly",       #no ksp used direct solve preconditioner
+        "-scale_vars":0,             #variable scaling method
+        "-scale_eqs":0,              #equation scaling method
+        "-snes_type":"newtonls",     # newton line search for nonliner solver
+        "-ts_adapt_type":"basic",
+        "-ts_adapt_dt_min":1e-1,
+        "-ts_max_time":100,            # final time
+        "-ts_save_trajectory":1,
+        "-ts_trajectory_type":"visualization",
+        #"-ts_exact_final_time":"stepover",
+        #"-ts_exact_final_time":"matchstep",
+        "-ts_exact_final_time":"interpolate",
+        #"-ts_view":""
+        })
+
+m.display()

--- a/petsc/examples/dae_pyomo/car_example_vis.py
+++ b/petsc/examples/dae_pyomo/car_example_vis.py
@@ -1,0 +1,37 @@
+"""
+Visualize the trajectory from example01.py. Assuming it was run with these
+options:
+
+    -ts_save_trajectory=1
+    -ts_trajectory_type=visualization
+
+That should put results from each time step in the directory Visualization-data
+
+To run this you need $PETSC_DIR/lib/petsc/bin/ in PYTHONPATH
+> export PYTHONPATH=$PYTHONPATH:$PETSC_DIR/lib/petsc/bin/
+"""
+
+from __future__ import division  # No integer division
+from __future__ import print_function  # Python 3 style print
+
+try:
+    import PetscBinaryIOTrajectory as pbt
+except:
+    pbt = None
+    print("Could not find PetscBinaryIOTrajectory.py.\n"
+          "Make sure the PETSc python files are in your PYTHONPATH\n"
+          "Try > export PYTHONPATH=$PYTHONPATH:$PETSC_DIR/lib/petsc/bin/")
+
+if __name__ == '__main__':
+    if pbt is None:
+        exit()
+    (t,v,names) = pbt.ReadTrajectory("Visualization-data")
+    with open('vars.col') as f:
+        names = list(map(str.strip, f.readlines()))
+    with open('vars.typ') as f:
+        typ = list(map(int,f.readlines()))
+    names = [name for i, name in enumerate(names) if typ[i] in [0,1]]
+    skip = ["xdummy", "timedummy"]
+    for name in names:
+        if name in skip: continue
+        pbt.PlotTrajectories(t,v,names,[name])

--- a/petsc/examples/dae_pyomo/chemakzo.py
+++ b/petsc/examples/dae_pyomo/chemakzo.py
@@ -1,0 +1,148 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+"""
+A test problem from https://archimede.dm.uniba.it/~testset/report/chemakzo.pdf
+"""
+from __future__ import division  # No integer division
+from __future__ import print_function  # Python 3 style print
+
+from pyomo.environ import ConcreteModel, Param, Var, Constraint, Suffix, SolverFactory
+
+if __name__ == "__main__":
+    opt = SolverFactory('petsc')
+    model = ConcreteModel(name="example01")
+
+    # Set problem parameter values
+    model.k = Param([1,2,3,4], initialize={
+        1:18.7,
+        2:0.58,
+        3:0.09,
+        4:0.42})
+    model.Ke = Param(initialize=34.4)
+    model.klA = Param(initialize=3.3)
+    model.Ks = Param(initialize=115.83)
+    model.pCO2 = Param(initialize=0.9)
+    model.H = Param(initialize=737)
+
+    # Problem variables ydot = dy/dt,
+    #    (dy6/dt is not explicitly in the equations, so only 5 ydots)
+    model.t = Var(initialize=0) #time, but not used anywhere could delete
+                                #using time explicilty in equations is possible
+    model.y = Var([1,2,3,4,5,6], initialize=1.0)  #
+    model.ydot = Var([1,2,3,4,5], initialize=1.0) # dy/dt
+    model.r = Var([1,2,3,4,5], initialize=1.0)
+    model.Fin = Var(initialize=1.0)
+
+    # Equations
+    model.eq_ydot1 = Constraint(expr=model.ydot[1] == -2.0*model.r[1] +
+        model.r[2] - model.r[3] - model.r[4])
+    model.eq_ydot2 = Constraint(expr=model.ydot[2] == -0.5*model.r[1] -
+        model.r[4] - 0.5*model.r[5] + model.Fin)
+    model.eq_ydot3 = Constraint(expr=model.ydot[3] == model.r[1] -
+        model.r[2] + model.r[3])
+    model.eq_ydot4 = Constraint(expr=model.ydot[4] == -model.r[2] + model.r[3] -
+        -2.0*model.r[4])
+    model.eq_ydot5 = Constraint(expr=model.ydot[5] == model.r[2] - model.r[3] +
+        model.r[5])
+    model.eq_y6 = Constraint(expr=0 == model.Ks*model.y[1]*model.y[4] -
+        model.y[6])
+
+    model.eq_r1 = Constraint(
+        expr=model.r[1] == model.k[1]*model.y[1]**4*model.y[2]**0.5)
+    model.eq_r2 = Constraint(
+        expr=model.r[2] == model.k[2]*model.y[3]*model.y[4])
+    model.eq_r3 = Constraint(
+        expr=model.r[3] == model.k[2]/model.Ke*model.y[1]*model.y[5])
+    model.eq_r4 = Constraint(
+        expr=model.r[4] == model.k[3]*model.y[1]*model.y[4]**2)
+    model.eq_r5 = Constraint(
+        expr=model.r[5] == model.k[4]*model.y[6]**2*model.y[2]**0.5)
+    model.eq_Fin = Constraint(
+        expr=model.Fin == model.klA*(model.pCO2/model.H - model.y[2]))
+
+    # Set initial condtions and solve initial from the values of differntial
+    # variables (r and y6 well and the derivative vars too).
+    y0 = {1:0.444, 2:0.00123, 3:0.0, 4:0.007, 5:0.0} #initial differntial vars
+    for i in [1,2,3,4,5]: model.y[i].fix(y0[i])
+
+    #---------------------------------------------------------------------------
+    # The scaling factor stuff here is just for testing and demonstration
+    # You don't need to supply scaling factors and if you do provide the
+    # scaling_factor suffix you don't need factors for each varibale and
+    # constaint.  These are used only for user scaling options
+    # "-scale_eqs 3" and "-scale_vars 1"
+    model.scaling_factor = Suffix(direction=Suffix.EXPORT, datatype=Suffix.FLOAT)
+    model.scaling_factor[model.Fin] = 0.5
+
+    model.scaling_factor[model.eq_Fin] = 100
+    #---------------------------------------------------------------------------
+
+    print("Solving initial conditions:")
+    res = opt.solve(
+        model,
+        tee=True,
+        options={
+            "-snes_monitor":"",
+            "-on_error_attach_debugger":"",
+            "-scale_vars":0,
+            "-scale_eqs":1})
+
+    for i in [1,2,3,4,5]: model.y[i].unfix()
+    model.display() # show the initial state
+
+    #Set suffixes to show the structure of the problem
+    # dae_suffix holds variable types 0=algebraic 1=differential 2=derivative
+    # 3=time. dae_link associates differential variables to their derivatives
+    model.dae_suffix = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
+    model.dae_link = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
+
+    # Label the vars.  Seems 0 is default if I don't attach a suffix so don't
+    # need to explicitly label algebraic vars
+    model.dae_suffix[model.t] = 3 # this labels t as the time variables
+    for i in [1,2,3,4,5]:
+        model.dae_suffix[model.y[i]] = 1 #differential vars
+        model.dae_suffix[model.ydot[i]] = 2 #derivative vars
+        #link the differential vars to the derivative var
+        model.dae_link[model.y[i]] = i
+        model.dae_link[model.ydot[i]] = i
+
+    print ("Solving DAE:")
+    # Solve threw in a lot of example options, but the important ones are
+    # the final time and the one to specify that it's a dae.  Probably also
+    # would want to specify a time step, or an adaptive time stepping method
+    res = opt.solve(model, tee=True,
+        options={
+            "-on_error_attach_debugger":"",
+            "-dae_solve":"",             #tell solver to expect dae problem
+            "-ts_monitor":"",            #show progess of TS solver
+            "-ts_max_snes_failures":40,  #max nonlin solve fails before give up
+            "-ts_max_reject":20,         #max steps to reject
+            "-ts_type":"alpha",          #ts_solver
+            "-snes_monitor":"",          #show progress on nonlinear solves
+            "-pc_type":"lu",             #direct solve MUMPS default LU fact
+            "-ksp_type":"preonly",       #no ksp used direct solve preconditioner
+            "-scale_vars":0,             #variable scaling method
+            "-scale_eqs":1,              #equation scaling method
+            #"-scale_eq_jac_max":100,    #set max J element to 1 for eq scaling
+            #"-show_scale_factors":"",
+            #"-show_jac":"",
+            #"-show_initial":"",
+            "-snes_type":"newtonls",     # newton line search for nonliner solver
+            "-ts_adapt_type":"basic",
+            "-ts_max_time":180,          # final time
+            "-ts_save_trajectory":1,
+            "-ts_trajectory_type":"visualization",
+            #"-ts_exact_final_time":"stepover",
+            #"-ts_exact_final_time":"matchstep",
+            "-ts_exact_final_time":"interpolate",
+            #"-ts_view":""
+            })
+    model.display() # display final state of the model (at -ts_max_time)

--- a/petsc/examples/dae_pyomo/chemakzo_vis.py
+++ b/petsc/examples/dae_pyomo/chemakzo_vis.py
@@ -1,0 +1,38 @@
+"""
+Visualize the trajectory from example01.py. Assuming it was run with these
+options:
+
+    -ts_save_trajectory=1
+    -ts_trajectory_type=visualization
+
+That should put results from each time step in the directory Visualization-data
+
+To run this you need $PETSC_DIR/lib/petsc/bin/ in PYTHONPATH
+> export PYTHONPATH=$PYTHONPATH:$PETSC_DIR/lib/petsc/bin/
+"""
+
+
+from __future__ import division  # No integer division
+from __future__ import print_function  # Python 3 style print
+
+try:
+    import PetscBinaryIOTrajectory as pbt
+except:
+    pbt = None
+    print("Could not find PetscBinaryIOTrajectory.py.\n"
+          "Make sure the PETSc python files are in your PYTHONPATH\n"
+          "Try > export PYTHONPATH=$PYTHONPATH:$PETSC_DIR/lib/petsc/bin/")
+
+if __name__ == '__main__':
+    if pbt is None:
+        exit()
+    (t,v,names) = pbt.ReadTrajectory("Visualization-data")
+    with open('vars.col') as f:
+        names = list(map(str.strip, f.readlines()))
+    with open('vars.typ') as f:
+        typ = list(map(int,f.readlines()))
+    names = [name for i, name in enumerate(names) if typ[i] in [0,1]]
+    pbt.PlotTrajectories(t,v,names,["y[1]", "y[3]", "y[6]"])
+    pbt.PlotTrajectories(t,v,names,["y[2]"])
+    pbt.PlotTrajectories(t,v,names,["y[4]"])
+    pbt.PlotTrajectories(t,v,names,["y[5]"])

--- a/petsc/examples/dae_pyomo/path_constraint.py
+++ b/petsc/examples/dae_pyomo/path_constraint.py
@@ -1,0 +1,123 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+# Sample Problem 3: Inequality State Path Constraint
+# (Ex 4 from Dynopt Guide)
+#
+#   min x3(tf)
+#   s.t.    X1_dot = X2                     X1(0) =  0
+#           X2_dot = -X2+u                  X2(0) = -1
+#           X3_dot = X1^2+x2^2+0.005*u^2    X3(0) =  0
+#           X2-8*(t-0.5)^2+0.5 <= 0
+#           tf = 1
+#
+
+# Modified for no optimization, and PETSc solver
+
+from pyomo.environ import ConcreteModel, Param, Var, Constraint, Suffix, SolverFactory
+
+m = ConcreteModel()
+m.tf = Param(initialize=1)
+m.t = Var() #ContinuousSet(bounds=(0,m.tf))
+
+m.u = Var(initialize=0) #Var(m.t, initialize=0)
+m.x1 = Var() #Var(m.t)
+m.x2 = Var() #Var(m.t)
+m.x3 = Var() #Var(m.t)
+
+m.dx1 = Var() #DerivativeVar(m.x1, wrt=m.t)
+m.dx2 = Var() #DerivativeVar(m.x2, wrt=m.t)
+m.dx3 = Var() #DerivativeVar(m.x3, wrt=m.t)
+
+#m.obj = Objective(expr=m.x3[m.tf])
+
+#def _x1dot(m, t):
+#    if t == 0:
+#        return Constraint.Skip
+#    return m.dx1[t] == m.x2[t]
+m.x1dotcon =  Constraint(expr=m.dx1 == m.x2) #Constraint(m.t, rule=_x1dot)
+
+#def _x2dot(m, t):
+#    if t == 0:
+#        return Constraint.Skip
+#    return m.dx2[t] ==  -m.x2[t]+m.u[t]
+m.x2dotcon =  Constraint(expr=m.dx2 ==  -m.x2+m.u)#Constraint(m.t, rule=_x2dot)
+
+#def _x3dot(m, t):
+#    if t == 0:
+#        return Constraint.Skip
+#    return m.dx3[t] == m.x1[t]**2+m.x2[t]**2+0.005*m.u[t]**2
+#m.x3dotcon = Constraint(m.t, rule=_x3dot)
+m.x3dotcon = Constraint(expr=m.dx3 == m.x1**2+m.x2**2+0.005*m.u**2)
+
+# Found a hole in the DAE solver, x3 isn't in the constraints so its not in the
+# nl file.  Added this constraint to force it in
+m.xdummy = Var()
+m.dummy = Constraint(expr=m.x3 == m.xdummy)
+
+#def _con(m, t):
+#    return m.x2[t]-8*(t-0.5)**2+0.5 <= 0
+#m.con = Constraint(m.t, rule=_con)
+
+#def _init(m):
+#    yield m.x1[0] == 0
+#    yield m.x2[0] == -1
+#    yield m.x3[0] == 0
+#m.init_conditions = ConstraintList(rule=_init)
+
+m.x1.value = 0
+m.x2.value = -1
+m.x3.value = 0
+m.u.fix()
+
+#Set suffixes to show the structure of the problem
+# dae_suffix holds variable types 0=algebraic 1=differential 2=derivative
+# 3=time. dae_link associates differential variables to their derivatives
+m.dae_suffix = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
+m.dae_link = Suffix(direction=Suffix.EXPORT, datatype=Suffix.INT)
+m.dae_suffix[m.t] = 3 # this labels t as the time variables (not really needed here)
+m.dae_suffix[m.x1] = 1
+m.dae_suffix[m.x2] = 1
+m.dae_suffix[m.x3] = 1
+m.dae_suffix[m.dx1] = 2
+m.dae_suffix[m.dx2] = 2
+m.dae_suffix[m.dx3] = 2
+# Link the differential vars to the derivatives
+m.dae_link[m.x1] = 1
+m.dae_link[m.x2] = 2
+m.dae_link[m.x3] = 3
+m.dae_link[m.dx1] = 1
+m.dae_link[m.dx2] = 2
+m.dae_link[m.dx3] = 3
+
+# Usually would solve initial condition first, but don't need to here
+opt = SolverFactory('petsc')
+res = opt.solve(m, tee=True,
+    options={
+        "-dae_solve":"",             #tell solver to expect dae problem
+        "-ts_monitor":"",            #show progess of TS solver
+        "-ts_max_snes_failures":40,  #max nonlin solve fails before give up
+        "-ts_max_reject":20,         #max steps to reject
+        "-ts_type":"alpha",          #ts_solver
+        "-snes_monitor":"",          #show progress on nonlinear solves
+        "-pc_type":"lu",             #direct solve MUMPS default LU fact
+        "-ksp_type":"preonly",       #no ksp used direct solve preconditioner
+        "-scale_vars":0,             #variable scaling method
+        "-scale_eqs":1,              #equation scaling method
+        "-snes_type":"newtonls",     # newton line search for nonliner solver
+        "-ts_adapt_type":"basic",
+        "-ts_max_time":2,            # final time
+        "-ts_save_trajectory":1,
+        "-ts_trajectory_type":"visualization",
+        #"-ts_exact_final_time":"stepover",
+        #"-ts_exact_final_time":"matchstep",
+        "-ts_exact_final_time":"interpolate",
+        #"-ts_view":""
+        })

--- a/petsc/examples/dae_pyomo/path_constraint_vis.py
+++ b/petsc/examples/dae_pyomo/path_constraint_vis.py
@@ -1,0 +1,35 @@
+"""
+Visualize the trajectory from example01.py. Assuming it was run with these
+options:
+
+    -ts_save_trajectory=1
+    -ts_trajectory_type=visualization
+
+That should put results from each time step in the directory Visualization-data
+
+To run this you need $PETSC_DIR/lib/petsc/bin/ in PYTHONPATH
+> export PYTHONPATH=$PYTHONPATH:$PETSC_DIR/lib/petsc/bin/
+"""
+
+
+from __future__ import division  # No integer division
+from __future__ import print_function  # Python 3 style print
+
+try:
+    import PetscBinaryIOTrajectory as pbt
+except:
+    pbt = None
+    print("Could not find PetscBinaryIOTrajectory.py.\n"
+          "Make sure the PETSc python files are in your PYTHONPATH\n"
+          "Try > export PYTHONPATH=$PYTHONPATH:$PETSC_DIR/lib/petsc/bin/")
+
+if __name__ == '__main__':
+    if pbt is None:
+        exit()
+    (t,v,names) = pbt.ReadTrajectory("Visualization-data")
+    with open('vars.col') as f:
+        names = list(map(str.strip, f.readlines()))
+    with open('vars.typ') as f:
+        typ = list(map(int,f.readlines()))
+    names = [name for i, name in enumerate(names) if typ[i] in [0,1]]
+    pbt.PlotTrajectories(t,v,names,["x1", "x2", "x3"])

--- a/petsc/examples/nl/t1.nl
+++ b/petsc/examples/nl/t1.nl
@@ -1,0 +1,137 @@
+g3 1 1 0	# problem example01
+ 12 12 0 0 12 	# vars, constraints, objectives, ranges, eqns
+ 1 0 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 1 0 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 30 0 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+o2
+n-1
+o2
+o2
+n0.42
+o5
+v0
+n2
+o5
+n0.00123
+n0.5
+C1
+n0
+C2
+n0
+C3
+n0
+C4
+n0
+C5
+n0
+C6
+n0
+C7
+n0
+C8
+n0
+C9
+n0
+C10
+n0
+C11
+n0
+x12
+0 0.35999964
+1 -0.05097681765216577
+2 -0.013729322308134246
+3 0.025487429806082887
+4 3.916080000000001e-06
+5 0.00190900022272292
+6 0.025487429806082887
+7 0.0
+8 0.0
+9 1.9580400000000004e-06
+10 0.00190900022272292
+11 -2.9149253731343243e-05
+r
+4 0.0
+4 0.0
+4 0.0
+4 0.0
+4 0.0
+4 0.0
+4 -0.35999964
+4 0.025487429806082887
+4 0.0
+4 0.0
+4 1.9580400000000004e-06
+4 -2.9149253731343243e-05
+b
+3
+3
+3
+3
+3
+3
+3
+3
+3
+3
+3
+3
+k11
+2
+3
+4
+5
+6
+7
+11
+16
+21
+25
+28
+J0 2
+10 1
+0 0
+J1 5
+1 1
+6 2.0
+7 -1
+8 1
+9 1
+J2 5
+2 1
+6 0.5
+9 1
+10 0.5
+11 -1
+J3 4
+3 1
+6 -1
+7 1
+8 -1
+J4 4
+4 1
+7 1
+8 -1
+9 -2.0
+J5 4
+5 1
+7 -1
+8 1
+10 -1
+J6 1
+0 -1
+J7 1
+6 1
+J8 1
+7 1
+J9 1
+8 1
+J10 1
+9 1
+J11 1
+11 1

--- a/petsc/fg_dae.c
+++ b/petsc/fg_dae.c
@@ -1,0 +1,135 @@
+#include"petsc.h"
+
+PetscErrorCode FormDAEFunction(TS ts, PetscReal t, Vec x, Vec xdot, Vec f, void *ctx){
+  Solver_ctx        *sol_ctx = (Solver_ctx*)ctx;
+  ASL               *asl=(ASL*)(sol_ctx->asl);
+  PetscErrorCode    ierr;
+  const PetscScalar *xx, *xxdot;     /* Variable vector*/
+  PetscScalar       *ff;
+  int               err=0;
+  int               i;
+  real              x_asl[n_var];
+
+  /* Take values from petsc vectors and put into ASL vector */
+  if(sol_ctx->dae_map_t > 0) x_asl[sol_ctx->dae_map_t] = t;
+  ierr = VecGetArrayRead(x, &xx); CHKERRQ(ierr);
+  ierr = VecGetArrayRead(xdot, &xxdot); CHKERRQ(ierr);
+  for(i=0;i<sol_ctx->n_var_state;++i){
+    x_asl[sol_ctx->dae_map_x[i]] = xx[i];
+    if(sol_ctx->dae_map_xdot[i] >= 0) x_asl[sol_ctx->dae_map_xdot[i]] = xxdot[i];
+  }
+  ierr = VecRestoreArrayRead(x,&xx);CHKERRQ(ierr);
+  ierr = VecRestoreArrayRead(xdot,&xxdot);CHKERRQ(ierr);
+  /* Compute */
+  ierr = VecGetArray(f,&ff);CHKERRQ(ierr);
+  conval(x_asl, (real*)ff, &err);
+  for(i=0;i<sol_ctx->n_var_state;++i) ff[i] -= LUrhs[i];
+  ierr = VecRestoreArray(f,&ff);CHKERRQ(ierr);
+  return 0;
+}
+
+PetscErrorCode FormDAEJacobian(
+  TS ts, PetscReal t, Vec x, Vec xdot, PetscReal sig, Mat jac, Mat B,void *ctx){
+  Solver_ctx        *sol_ctx = (Solver_ctx*)ctx;
+  ASL               *asl=(ASL*)(sol_ctx->asl);
+  const PetscScalar *xx, *xxdot;     /* Variable vector*/
+  PetscScalar       A[nzc];  /* Temporary storage for Jacobian Calc. */
+  PetscErrorCode    ierr;    /* PETSc Error code */
+  int               err;     /* ASL Error code */
+  unsigned long int i, j;    /* Constraint index, var */
+  cgrad             *cg;     /* Constraint gradient information */
+  real              x_asl[n_var];
+
+  /* Compute Jacobian entries */
+  /* Take values from petsc vectors and put into ASL vector */
+  if(sol_ctx->dae_map_t > 0) x_asl[sol_ctx->dae_map_t] = t;
+  ierr = VecGetArrayRead(x, &xx); CHKERRQ(ierr);
+  ierr = VecGetArrayRead(xdot, &xxdot); CHKERRQ(ierr);
+  for(i=0;i<sol_ctx->n_var_state;++i){
+    x_asl[sol_ctx->dae_map_x[i]] = xx[i];
+    if(sol_ctx->dae_map_xdot[i] >= 0) x_asl[sol_ctx->dae_map_xdot[i]] = xxdot[i];
+  }
+  ierr = VecRestoreArrayRead(x,&xx);CHKERRQ(ierr);
+  ierr = VecRestoreArrayRead(xdot,&xxdot);CHKERRQ(ierr);
+  jacval((real*)x_asl, (real*)A, &err);
+  /* The ASL isn't setup for DAEs, but not too hard to make the right Jacobian
+    From asl we have a Jacobian where t, x, and xdot are all treated the same,
+    PETSc want J = sigma*F_xdot(t, x, xdot) + F_x(t, x, xdot), so we need to
+    eliminate the t column and combine the x and xdot columns appropriatly */
+  ierr = MatZeroEntries(B); CHKERRQ(ierr); //since I'm going to add things
+  for(i=n_conjac[0];i<n_conjac[1]; ++i){ /*i is constraint index */
+    cg = Cgrad[i];
+    while(cg!=NULL){
+      j = cg->varno;
+      if(sol_ctx->dae_suffix_var->u.i[j]==2){
+        MatSetValue(B, i, sol_ctx->dae_map_back[j], sig*A[cg->goff], ADD_VALUES);}
+      else if(sol_ctx->dae_suffix_var->u.i[j]==3); //drop t
+      else MatSetValue(B, i, sol_ctx->dae_map_back[j], A[cg->goff], ADD_VALUES);
+      cg=cg->next;
+    }
+  }
+  /* Assemble matrix */
+  ierr = MatAssemblyBegin(B,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+  ierr = MatAssemblyEnd(B,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+  return 0;
+}
+
+void dae_var_map(Solver_ctx *sol_ctx){
+  int i=0, j=0, cx;
+  ASL *asl=(ASL*)(sol_ctx->asl); //need this for ASL macros
+
+  /* create a mapping PETSc <-> asl */
+  sol_ctx->dae_link = (int*)malloc(n_var*sizeof(int));
+  for(i=0;i<n_var;++i) sol_ctx->dae_link[i] = -1;
+  for(i=0;i<n_var;++i){
+    if(sol_ctx->dae_suffix_var->u.i[i]==2){ //a derivative var
+      for(j=0;j<n_var;++j){
+        if(i == j) continue;
+        if(sol_ctx->dae_link_var->u.i[i] == sol_ctx->dae_link_var->u.i[j]){
+          sol_ctx->dae_link[i] = j;
+          sol_ctx->dae_link[j] = i;
+        }
+      } //end for j
+    } //end if suffix == 2
+  } //end for i
+  sol_ctx->dae_map_x = (int*)malloc(sol_ctx->n_var_state*sizeof(int));
+  sol_ctx->dae_map_xdot = (int*)malloc(sol_ctx->n_var_state*sizeof(int));
+  sol_ctx->dae_map_back = (int*)malloc(n_var*sizeof(int));
+  for(i=0;i<sol_ctx->n_var_state;++i) sol_ctx->dae_map_xdot[i] = -1;
+  cx = 0;
+  for(i=0;i<n_var;++i){
+    if (sol_ctx->dae_suffix_var->u.i[i]==3){ //time variable (0 or 1 of these)
+      sol_ctx->dae_map_t = i;
+    }
+    else if (sol_ctx->dae_suffix_var->u.i[i]==2);
+    else{ //agebraic and differential variables
+      sol_ctx->dae_map_x[cx] = i;
+      sol_ctx->dae_map_back[i] = cx;
+      ++cx;
+    }
+  } //end for i
+  for(i=0;i<n_var;++i){
+    // there is a derivative in xdot for all state vars, but in a dae some are
+    // just going to be zero in the function and jacobian calcualtions.
+    if (sol_ctx->dae_suffix_var->u.i[i] == 1){
+      j = sol_ctx->dae_link[i]; // index of associated derivative
+      sol_ctx->dae_map_xdot[sol_ctx->dae_map_back[i]] = j;
+      sol_ctx->dae_map_back[j] = sol_ctx->dae_map_back[i];
+    }//end if suffix == 1
+  }// end for i
+}
+
+void get_dae_info(Solver_ctx *sol_ctx){
+  int i=0;
+  ASL *asl=(ASL*)(sol_ctx->asl); //need this for ASL macros
+
+  sol_ctx->dae_suffix_var = suf_get("dae_suffix", ASL_Sufkind_var);
+  sol_ctx->dae_link_var = suf_get("dae_link", ASL_Sufkind_var);
+  for(i=0; i<n_var; ++i){
+    if(sol_ctx->dae_suffix_var->u.i[i]==1) ++sol_ctx->n_var_diff;
+    else if(sol_ctx->dae_suffix_var->u.i[i]==2) ++sol_ctx->n_var_deriv;
+    else if(sol_ctx->dae_suffix_var->u.i[i]==3) ++sol_ctx->explicit_time;
+  }
+  sol_ctx->n_var_state = n_var - sol_ctx->n_var_deriv - sol_ctx->explicit_time;
+  sol_ctx->n_var_alg = sol_ctx->n_var_state - sol_ctx->n_var_diff;
+}

--- a/petsc/fg_nl.c
+++ b/petsc/fg_nl.c
@@ -1,0 +1,107 @@
+#include"petsc.h"
+
+PetscErrorCode FormFunction(SNES snes,Vec x,Vec f, void *ctx){
+  Solver_ctx        *sol_ctx = (Solver_ctx*)ctx;
+  ASL               *asl=(ASL*)(sol_ctx->asl);
+  PetscErrorCode    ierr;
+  const PetscScalar *xx;
+  PetscScalar       *ff;
+  int               err=0;
+  int               i;
+
+  /* Get pointers to residual and variable data */
+  ierr = VecGetArrayRead(x,&xx);CHKERRQ(ierr);
+  ierr = VecGetArray(f,&ff);CHKERRQ(ierr);
+  /* Compute function */
+  conval((real*)xx, (real*)ff, &err);
+  for(i=n_conjac[0];i<n_conjac[1];++i){
+    ff[i] -= LUrhs[i];
+  }
+  /* Restore vectors */
+  ierr = VecRestoreArrayRead(x,&xx);CHKERRQ(ierr);
+  ierr = VecRestoreArray(f,&ff);CHKERRQ(ierr);
+  return 0;
+}
+
+PetscErrorCode FormJacobian(SNES snes,Vec x,Mat jac,Mat B,void *ctx){
+  Solver_ctx        *sol_ctx = (Solver_ctx*)ctx;
+  ASL               *asl=(ASL*)(sol_ctx->asl);
+  const PetscScalar *xx;     /* Variable vector*/
+  PetscScalar       A[nzc];  /* Temporary storage for Jacobian Calc. */
+  PetscErrorCode    ierr;    /* PETSc Error code */
+  int               err;     /* ASL Error code */
+  unsigned long int i;       /* Constraint index */
+  cgrad             *cg;     /* Constraint gradient information */
+
+  /* Compute Jacobian entries and insert into matrix. */
+  ierr = VecGetArrayRead(x,&xx);CHKERRQ(ierr);
+  jacval((real*)xx,(real*)A,&err);
+  ierr = VecRestoreArrayRead(x,&xx);CHKERRQ(ierr);
+
+  for(i=n_conjac[0];i<n_conjac[1]; ++i){ /*i is constraint index */
+    cg = Cgrad[i];
+    while(cg!=NULL){
+      MatSetValue(B, i, cg->varno, A[cg->goff],INSERT_VALUES);
+      cg=cg->next;
+    }
+  }
+  /* Assemble matrix */
+  ierr = MatAssemblyBegin(B,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+  ierr = MatAssemblyEnd(B,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+  return 0;
+}
+
+int get_snes_sol_message(char *msg, SNESConvergedReason term_reason, ASL *asl){
+  //solve_result_num is an ASL macro.  I stole the code numbers from ipopt
+  //so at least I know pyomo will recognize them.  I havent found documentation
+  //yet.
+  if(term_reason==SNES_CONVERGED_ITERATING){
+    strcpy(msg, "SNES_CONVERGED_ITERATING");
+    solve_result_num = 2;}
+  else if(term_reason==SNES_CONVERGED_FNORM_ABS){
+    strcpy(msg, "SNES_CONVERGED_FNORM_ABS");
+    solve_result_num = 2;}
+  else if(term_reason==SNES_CONVERGED_FNORM_RELATIVE){
+    strcpy(msg, "SNES_CONVERGED_FNORM_RELATIVE");
+    solve_result_num = 2;}
+  else if(term_reason==SNES_CONVERGED_SNORM_RELATIVE){
+    strcpy(msg, "SNES_CONVERGED_SNORM_RELATIVE");
+    solve_result_num = 2;}
+  else if(term_reason==SNES_CONVERGED_ITS){
+    strcpy(msg, "SNES_CONVERGED_ITS");
+    solve_result_num = 400;}
+  else if(term_reason==SNES_CONVERGED_TR_DELTA){
+    strcpy(msg, "SNES_CONVERGED_TR_DELTA");
+    solve_result_num = 2;}
+  else if(term_reason==SNES_DIVERGED_FUNCTION_DOMAIN){
+    strcpy(msg, "SNES_DIVERGED_FUNCTION_DOMAIN");
+    solve_result_num = 300;}
+  else if(term_reason==SNES_DIVERGED_FUNCTION_COUNT){
+    strcpy(msg, "SNES_DIVERGED_FUNCTION_COUNT");
+    solve_result_num = 300;}
+  else if(term_reason==SNES_DIVERGED_LINEAR_SOLVE){
+    strcpy(msg, "SNES_DIVERGED_LINEAR_SOLVE");
+    solve_result_num = 300;}
+  else if(term_reason==SNES_DIVERGED_FNORM_NAN){
+    strcpy(msg, "SNES_DIVERGED_FNORM_NAN");
+    solve_result_num = 300;}
+  else if(term_reason==SNES_DIVERGED_MAX_IT){
+    strcpy(msg, "SNES_DIVERGED_MAX_IT");
+    solve_result_num = 400;}
+  else if(term_reason==SNES_DIVERGED_LINE_SEARCH){
+    strcpy(msg, "SNES_DIVERGED_LINE_SEARCH");
+    solve_result_num = 300;}
+  else if(term_reason==SNES_DIVERGED_INNER){
+    strcpy(msg, "SNES_DIVERGED_INNER");
+    solve_result_num = 300;}
+  else if(term_reason==SNES_DIVERGED_LOCAL_MIN){
+    strcpy(msg, "SNES_DIVERGED_LOCAL_MIN");
+    solve_result_num = 200;}
+  else if(term_reason==SNES_DIVERGED_DTOL){
+    strcpy(msg, "SNES_DIVERGED_DTOL");
+    solve_result_num = 300;}
+  else{
+    strcpy(msg, "Unknown Error");
+    solve_result_num = 500;}
+  return solve_result_num;
+}

--- a/petsc/help.h
+++ b/petsc/help.h
@@ -1,0 +1,34 @@
+
+/* Help message prepended to the regular PETSc help */
+
+static char help[] ="\
+--------------------------------------------------------------------------\n\
+Use ASL and PETSc to solve a problem (non-linear equations or DAE) defined \n\
+in an AMPL nl file. Optimization solver support will be added soon.\n\n\
+   Added Options: \n\
+     [filename]: File name with or without extension (when -s is not specified) \n\
+     -s <stub>: File name with or without extension\n\
+     -show_scale_factors: Show the calculated or user specified scale factors\n\
+     -show_jac: Show non-zero jacobian values at initial point\n\
+     -show_intial: Show the guess intial values \n\
+     -show_cl: Show the command line input and transformation from AMPL format\n\
+     -perturb_test <factor>: Test using nl file where initial value is solution \n\
+        This just multiplies the inital value by factor and resolves, then it \n\
+        compares the new solution to the intial value and report differnces > \n\
+        1e-6. It's a fairly crude test but it should ensure the Jacobian and \n\
+        function are calculating right.\n\
+     -dae_solve: Run DAE solver, must provide appropriate suffixes\n\
+     -jac_explicit_diag: Create explicit Jacobian entries in diagonal\n\
+     -scale_eqs <method>: Equation scaling method:\n\
+        0 - None\n\
+        1 - Auto scale based on Jacobian values at initial point\n\
+        2 - (Not Implimented) Auto scale based on Jacobian values at\n\
+          multiple points selected randomly.\n\
+        3 - User defined scaling factors specified in 'scaling_factor' suffix\n\
+     -scale_vars <method>: \n\
+        0 - None\n\
+        1 - User defined scaling factors specified in 'scaling_factor' suffix\n\
+   Equation scaling options:\n\
+     -scale_eq_jac_max: Maximum Jacobian after scaling (default 100)\n\
+     -scale_eq_fac_min: Minimum equation scaling factor (default 1e-6)\n\
+    ";

--- a/petsc/petsc.c
+++ b/petsc/petsc.c
@@ -1,0 +1,401 @@
+/*
+AMPL solver interface for PETSc
+John Eslick
+*/
+
+//TODO<jce> Need to return asl solver status code for DAE solver
+//TODO<jce> Add TAO optimization solvers
+
+#include"help.h"
+#include"petsc.h"
+#include<stdio.h>
+#include<math.h>
+
+int main(int argc, char **argv){
+  PetscErrorCode ierr;        // Error code from PETSc functions
+  PetscInt       its;         // Number of solver iterations
+  ASL            *asl;        // ASL context
+  Solver_ctx     sol_ctx;     // solver context
+  int            err;         // Error code  from ASL fulctions
+  int            i=0;         // Loop counters
+  PetscInt       temp_int;    // a temporary variable to store a option
+  PetscScalar    temp_scalar; // a temporary scalar for reading options
+  PetscBool      temp_bool;   // a temporart bool for reading options
+  int            argc_new;    // new number of arguments reformated for PETSc
+  char           **argv_new;  // argv transformed to PETSc's format
+  static SufDecl suftab[] = { // suffixes to read in
+    //doc for this at https://ampl.com/netlib/ampl/solvers/README.suf
+    {"dae_suffix", NULL, ASL_Sufkind_var}, //var kinds for DAE solver
+    {"dae_link",   NULL, ASL_Sufkind_var}, //link derivatives to vars
+    {"scaling_factor", NULL, ASL_Sufkind_var|ASL_Sufkind_real}, //var scale factors
+    {"scaling_factor", NULL, ASL_Sufkind_con|ASL_Sufkind_real} //constraint scale factors
+  };
+  Vec            x,r,xl,xu; // solution, residual, bound vectors
+  Mat            J;            // Jacobian matrix
+  TS             ts;           // DAE solver
+  SNES           snes;         // nonlinear solver context
+  KSP            ksp;          // linear solver context
+  PC             pc;           // linear preconditioner context
+  SNESLineSearch linesearch;   // line search context
+  SNESConvergedReason cr; // reason for convergence (or lack of convergence)
+  char           msg[MSG_BUF_SIZE]; // just a string buffer
+  PetscScalar    *xx, *xxl, *xxu; // for accessing x, xlb, and xub vectors
+  real t; //time for DAE solution
+  TSConvergedReason tscr;
+  real *x_asl;
+  PetscViewer pv;
+
+  // Set some initial values in sol_ctx
+  sol_ctx_init(&sol_ctx);
+  // Change the AMPL style args into what PETSc would expect
+  argv_new = transform_args(argc, argv, &argc_new);
+  // Initialize up PETSc stuff
+  PetscInitialize(&argc_new, &argv_new, (char*)0, help);
+  ierr = MPI_Comm_size(PETSC_COMM_WORLD, &sol_ctx.opt.mpi_size);CHKERRQ(ierr);
+  // Get added options
+  PetscOptionsGetString(NULL, NULL, "-s", sol_ctx.opt.stub, PETSC_MAX_PATH_LEN-1, &sol_ctx.opt.got_stub);
+  PetscOptionsHasName(NULL, NULL, "-show_jac", &sol_ctx.opt.show_jac);
+  PetscOptionsHasName(NULL, NULL, "-show_initial", &sol_ctx.opt.show_init);
+  PetscOptionsHasName(NULL, NULL, "-show_scale_factors", &sol_ctx.opt.show_scale_factors);
+  PetscOptionsHasName(NULL, NULL, "-use_bounds", &sol_ctx.opt.use_bounds);
+  PetscOptionsGetScalar(NULL, NULL, "-perturb_test",&sol_ctx.opt.ptest, &sol_ctx.opt.per_test);
+  if(!sol_ctx.opt.per_test) sol_ctx.opt.ptest = 1.0;
+  PetscOptionsGetInt(NULL, NULL, "-scale_eqs", &temp_int, &sol_ctx.opt.scale_eq);
+  sol_ctx.opt.eq_scale_method = (EQSCALE_TYPE)temp_int;
+  PetscOptionsGetInt(NULL, NULL, "-scale_vars", &temp_int, &sol_ctx.opt.scale_var);
+  sol_ctx.opt.var_scale_method = (VARSCALE_TYPE)temp_int;
+  PetscOptionsHasName(NULL, NULL, "-AMPL", &sol_ctx.opt.ampl_opt); // I don't use this
+  PetscOptionsHasName(NULL, NULL, "-jac_explicit_diag", &sol_ctx.opt.jac_explicit_diag);
+  PetscOptionsHasName(NULL, NULL, "-dae_solve", &sol_ctx.opt.dae_solve);
+  PetscOptionsHasName(NULL, NULL, "-show_cl", &sol_ctx.opt.show_cl);
+  PetscOptionsGetScalar(NULL, NULL, "-scale_eq_jac_max",&temp_scalar, &temp_bool);
+  if(temp_bool) sol_ctx.opt.scale_eq_jac_max = temp_scalar;
+  else sol_ctx.opt.scale_eq_jac_max = 100;
+  PetscOptionsGetScalar(NULL, NULL, "-scale_eq_fac_min",&temp_scalar, &temp_bool);
+  if(temp_bool) sol_ctx.opt.scale_eq_fac_min = temp_scalar;
+  else sol_ctx.opt.scale_eq_fac_min = 1e-6;
+
+  // If show_cl otion, show the original and transformed command line
+  if(sol_ctx.opt.show_cl){
+    PetscPrintf(PETSC_COMM_SELF, "-----------------------------------------------------------------\n");
+    print_commandline("Original Exec:\n  ", argc, argv);
+    print_commandline("Transformed Exec:\n  ", argc_new, argv_new);
+    PetscPrintf(PETSC_COMM_SELF, "-----------------------------------------------------------------\n");
+  }
+  // Make sure that a file was specified, and get the string length
+  if(!sol_ctx.opt.got_stub) strcpy(sol_ctx.opt.stub, argv[1]); //assume first arg is file if no -s
+  if(sol_ctx.opt.stub[0]=='-') exit(P_EXIT_NL_FILE_ERROR); // is an option name not filename
+  sol_ctx.opt.stublen = strlen(sol_ctx.opt.stub);
+  // Create ASL context and read nl file
+  sol_ctx.asl = ASL_alloc(ASL_read_fg); // asl context
+  asl = sol_ctx.asl;
+  // set the suffix data structure
+  suf_declare(suftab, sizeof(suftab)/sizeof(SufDecl));
+  // get file pointer and basic problem info from nl file
+  sol_ctx.nl = jac0dim(sol_ctx.opt.stub, sol_ctx.opt.stublen);
+  if(sol_ctx.nl==NULL){
+      PetscPrintf(PETSC_COMM_SELF, "Could not read nl file %s\n", sol_ctx.opt.stub);
+      exit(P_EXIT_NL_FILE_ERROR);
+  }
+  // Allocated space for some ASL items and test calculations
+  X0 = (real*)Malloc(n_var*sizeof(real));  /* Initial X values */
+  LUv = (real*)Malloc(n_var*sizeof(real)); /* Variable lower bounds */
+  Uvx = (real*)Malloc(n_var*sizeof(real)); /* Variable upper bounds */
+  LUrhs = (real*)Malloc(n_con*sizeof(real)); /* Lower constraint right side */
+  Urhsx = (real*)Malloc(n_con*sizeof(real)); /* Upper constraint right side */
+  // count inequalities
+  for(i=0; i<n_con; ++i) if(LUrhs[i] - Urhsx[i] > 1e-10) ++sol_ctx.n_ineq;
+  // count degrees of freedom (n_var and n_con are macros from asl.h)
+  sol_ctx.dof = n_var - n_con + sol_ctx.n_ineq;
+  // Print basic problem information
+  PetscPrintf(PETSC_COMM_SELF, "---------------------------------------------------\n");
+  PetscPrintf(PETSC_COMM_SELF, "DAE: %d\n", sol_ctx.opt.dae_solve);
+  PetscPrintf(PETSC_COMM_SELF, "Reading nl file: %s\n", sol_ctx.opt.stub);
+  PetscPrintf(PETSC_COMM_SELF, "Number of constraints: %d\n", n_con);
+  PetscPrintf(PETSC_COMM_SELF, "Number of nonlinear constraints: %d\n", nlc);
+  PetscPrintf(PETSC_COMM_SELF, "Number of linear constraints: %d\n", n_con-nlc);
+  PetscPrintf(PETSC_COMM_SELF, "Number of inequalities: %d\n", sol_ctx.n_ineq);
+  PetscPrintf(PETSC_COMM_SELF, "Number of variables: %d\n", n_var);
+  PetscPrintf(PETSC_COMM_SELF, "Number of integers: %d\n", niv);
+  PetscPrintf(PETSC_COMM_SELF, "Number of binary: %d\n", nbv);
+  PetscPrintf(PETSC_COMM_SELF, "Number of objectives: %d (Ignoring)\n", n_obj);
+  PetscPrintf(PETSC_COMM_SELF, "Number of non-zeros in Jacobian: %d \n", nzc);
+  PetscPrintf(PETSC_COMM_SELF, "Number of degrees of freedom: %d\n", sol_ctx.dof);
+  // There are some restrictions (at least for now) to check
+  if(nbv + niv > 0){ // no integer vars (nbv and niv are ASL macros)
+    PetscPrintf(PETSC_COMM_SELF, "ERROR: Contains integer or binary variables.");
+    ASL_free(&(sol_ctx.asl));
+    exit(P_EXIT_INTEGER);}
+  else if(sol_ctx.dof != 0 && !sol_ctx.opt.dae_solve){ //dof must == 0 for nonlinear solve
+    PetscPrintf(PETSC_COMM_SELF, "ERROR: Degrees of freedom not equal to 0\n");
+    ASL_free(&(sol_ctx.asl));
+    exit(P_EXIT_DOF);}
+  else if(sol_ctx.n_ineq > 0){ // no inequalities for nonlinear sys or DAE
+    PetscPrintf(PETSC_COMM_SELF, "ERROR: contains inequalities");
+    ASL_free(&(sol_ctx.asl));
+    exit(P_EXIT_INEQ);}
+  // Read nl file and make function for jacobian
+  err = fg_read(sol_ctx.nl, 0);
+  PetscPrintf(PETSC_COMM_SELF, "Called fg_read, err: %d (0 is good)\n", err);
+  // If DAES, get DAE var types and map vars between ASL and PETSc
+  if(sol_ctx.opt.dae_solve){
+    get_dae_info(&sol_ctx);
+    dae_var_map(&sol_ctx);
+    PetscPrintf(PETSC_COMM_SELF, "Explicit time variable: %d\n", sol_ctx.explicit_time);
+    PetscPrintf(PETSC_COMM_SELF, "Number of derivatives: %d\n", sol_ctx.n_var_deriv);
+    PetscPrintf(PETSC_COMM_SELF, "Number of differential vars: %d\n", sol_ctx.n_var_diff);
+    PetscPrintf(PETSC_COMM_SELF, "Number of algebraic vars: %d\n", sol_ctx.n_var_alg);
+    PetscPrintf(PETSC_COMM_SELF, "Number of state vars: %d\n", sol_ctx.n_var_state);
+    if(sol_ctx.explicit_time>1){
+      PetscPrintf(PETSC_COMM_SELF, "ERROR: DAE: Multiple time variable (allowed 1 at most)");
+      ASL_free(&(sol_ctx.asl));
+      exit(P_EXIT_MULTIPLE_TIME);
+    }
+    if(sol_ctx.dof != sol_ctx.n_var_deriv + sol_ctx.explicit_time){
+      PetscPrintf(PETSC_COMM_SELF, "ERROR: DAE: DOF != number of derivative vars");
+      ASL_free(&(sol_ctx.asl));
+      exit(P_EXIT_DOF_DAE);
+    }
+    if(sol_ctx.n_var_diff != sol_ctx.n_var_deriv){
+      PetscPrintf(PETSC_COMM_SELF, "ERROR: DAE: number of differential vars != number of derivatives");
+      ASL_free(&(sol_ctx.asl));
+      exit(P_EXIT_VAR_DAE_MIS);
+    }
+  }
+  PetscPrintf(PETSC_COMM_SELF, "---------------------------------------------------\n");
+
+  // Equation/variable scaling
+  sol_ctx.dae_suffix_var = suf_get("dae_suffix", ASL_Sufkind_var);
+  sol_ctx.dae_link_var = suf_get("dae_link", ASL_Sufkind_var);
+  sol_ctx.scaling_factor_var = suf_get("scaling_factor", ASL_Sufkind_var);
+  sol_ctx.scaling_factor_con = suf_get("scaling_factor", ASL_Sufkind_con);
+
+  if(sol_ctx.opt.dae_solve){  //This block sets up DAE solve and solves
+    ierr = TSCreate(PETSC_COMM_WORLD, &ts); CHKERRQ(ierr);
+    ierr = VecCreate(PETSC_COMM_WORLD,&x); CHKERRQ(ierr); //create an x vector
+    ierr = VecSetSizes(x, PETSC_DECIDE, sol_ctx.n_var_state); CHKERRQ(ierr);
+    ierr = VecSetFromOptions(x); CHKERRQ(ierr); //command line options for vec
+    ierr = VecDuplicate(x, &r);CHKERRQ(ierr);  // duplicate x for resuiduals
+    /* Make x vec set initial guess from nl file, also get lb and ub */
+    ierr = VecGetArray(x,&xx);CHKERRQ(ierr);
+    for(i=0;i<n_var;++i){
+      if(sol_ctx.dae_suffix_var->u.i[i]!=2 && sol_ctx.dae_suffix_var->u.i[i]!=3){
+        xx[sol_ctx.dae_map_back[i]] = X0[i];
+      }
+    }
+    // Equation/variable scaling
+    ScaleVars(&sol_ctx);
+    ScaleEqs(&sol_ctx);
+    // Print the variable types for reading trajectories
+    strcpy(sol_ctx.opt.typ_file, sol_ctx.opt.stub);
+    if(sol_ctx.opt.stublen > 3){
+      if((sol_ctx.opt.stub[sol_ctx.opt.stublen - 1] == 'l') &&
+         (sol_ctx.opt.stub[sol_ctx.opt.stublen - 2] == 'n') &&
+         (sol_ctx.opt.stub[sol_ctx.opt.stublen - 3] == '.')){
+        strcpy(sol_ctx.opt.typ_file + sol_ctx.opt.stublen - 3, ".typ");
+      }
+      else{ //just stub no ".nl" extension
+        strcpy(sol_ctx.opt.typ_file + sol_ctx.opt.stublen, ".typ");
+      }
+    }
+    else{// not long enough for there to be an extension
+      strcpy(sol_ctx.opt.typ_file + sol_ctx.opt.stublen, ".typ");
+    }
+
+    err = PetscViewerASCIIOpen(PETSC_COMM_WORLD, sol_ctx.opt.typ_file, &pv);
+    for(i=0;i<n_var;++i){
+      PetscViewerASCIIPrintf(pv, "%d\n", sol_ctx.dae_suffix_var->u.i[i]);
+    }
+    err = PetscViewerDestroy(&pv);
+
+
+    print_init_diagnostic(&sol_ctx); //print initial diagnostic information
+    ierr = VecRestoreArray(x, &xx);CHKERRQ(ierr);
+    // Make Jacobian matrix (by default sparse AIJ)
+    ierr = MatCreate(PETSC_COMM_WORLD,&J); CHKERRQ(ierr);
+    ierr = MatSetSizes(J, PETSC_DECIDE, PETSC_DECIDE, n_con, sol_ctx.n_var_state); CHKERRQ(ierr);
+    ierr = MatSetFromOptions(J); CHKERRQ(ierr); //command line options override defaults
+    ierr = MatSetUp(J); CHKERRQ(ierr);
+    /* Explicitly add diagonal elements if needed (some preconditioners need)*/
+    for(i=n_conjac[0];i<n_conjac[1]; ++i){
+      ierr = MatSetValue(J, i, i, 0.0, INSERT_VALUES);CHKERRQ(ierr);
+    }
+    /* finish up jacobian */
+    ierr = MatAssemblyBegin(J,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+    ierr = MatAssemblyEnd(J,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+    /* Set residual and jacobian functions */
+    ierr = TSSetIFunction(ts, r, FormDAEFunction, &sol_ctx);CHKERRQ(ierr);
+    ierr = TSSetIJacobian(ts, J, J, FormDAEJacobian, &sol_ctx);CHKERRQ(ierr);
+    /* First set a bunch of default options, then read CL to override */
+    ierr = TSSetProblemType(ts, TS_NONLINEAR);
+    ierr = TSSetEquationType(ts, TS_EQ_IMPLICIT);
+    ierr = TSGetSNES(ts, &snes);CHKERRQ(ierr);
+    ierr = SNESGetKSP(snes, &ksp);CHKERRQ(ierr);
+    ierr = SNESGetLineSearch(snes, &linesearch);CHKERRQ(ierr);
+    ierr = SNESLineSearchSetType(linesearch, SNESLINESEARCHBT);
+    ierr = KSPGetPC(ksp,&pc);CHKERRQ(ierr);
+    ierr = PCSetType(pc,DEFAULT_PC);CHKERRQ(ierr);
+    ierr = PCFactorSetMatSolverType(pc, DEFAULT_LINEAR_PACK);CHKERRQ(ierr);
+    ierr = PCFactorReorderForNonzeroDiagonal(pc, 1e-10);CHKERRQ(ierr);
+    ierr = KSPSetType(ksp,DEFAULT_KSP);CHKERRQ(ierr);
+    ierr = TSSetTimeStep(ts, 1);
+    ierr = TSSetMaxTime(ts, 10);
+    ierr = TSSetExactFinalTime(ts, TS_EXACTFINALTIME_MATCHSTEP);
+    // Set up solver from CL options
+    ierr = TSSetFromOptions(ts);CHKERRQ(ierr);
+    // Solve
+    ierr = TSSolve(ts, x);
+    ierr = TSGetTime(ts, &t);
+    ierr = SNESGetConvergedReason(snes, &cr); CHKERRQ(ierr);
+    ierr = TSGetConvergedReason(ts, &tscr); CHKERRQ(ierr);
+    /* Get the results */
+    x_asl = (real*)malloc((n_var)*sizeof(real));
+    ierr = VecGetArray(x, &xx);CHKERRQ(ierr);
+    for(i=0;i<sol_ctx.n_var_state;++i) x_asl[sol_ctx.dae_map_x[i]] = xx[i];
+    ierr = VecRestoreArray(x,&xx);CHKERRQ(ierr);
+    if(sol_ctx.explicit_time) x_asl[sol_ctx.dae_map_t] = t;
+    /* write the AMPL solution file */
+    sprintf(msg, "TSConvergedReason = %d", tscr);  //Reason it stopped
+    write_sol(msg, x_asl, NULL, NULL); // write ASL sol file
+    ierr = TSDestroy(&ts);
+  } //end ts solve
+  else{ // nonlinear solver setup and solve
+    // Equation/variable scaling
+    ScaleVars(&sol_ctx);
+    ScaleEqs(&sol_ctx);
+    // Print requested diagnostic info
+    print_init_diagnostic(&sol_ctx);
+    /*Create nonlinear solver context*/
+    ierr = SNESCreate(PETSC_COMM_WORLD, &snes); CHKERRQ(ierr);
+    /*Create vectors for solution and nonlinear function*/
+    ierr = VecCreate(PETSC_COMM_WORLD,&x); CHKERRQ(ierr); //create an x vector
+    ierr = VecSetSizes(x,PETSC_DECIDE,n_var);CHKERRQ(ierr); //vecs are n_vars long
+    ierr = VecSetFromOptions(x);CHKERRQ(ierr); //command line options for vec
+    ierr = VecDuplicate(x,&r);CHKERRQ(ierr);  // duplicate x for resuiduals
+    ierr = VecDuplicate(x,&xl);CHKERRQ(ierr); // duplicate x for lower bounds
+    ierr = VecDuplicate(x,&xu);CHKERRQ(ierr); // duplicate x for upper bounds
+    //Make Jacobian matrix (by default sparse AIJ)
+    ierr = MatCreate(PETSC_COMM_WORLD,&J);CHKERRQ(ierr);
+    ierr = MatSetSizes(J,PETSC_DECIDE,PETSC_DECIDE,n_con,n_var);CHKERRQ(ierr);
+    ierr = MatSetFromOptions(J);CHKERRQ(ierr); //command line options override defaults
+    ierr = MatSetUp(J);CHKERRQ(ierr);
+    /* Explicitly add diagonal elements if needed (some preconditioners need)*/
+    if(sol_ctx.opt.jac_explicit_diag) for(i=n_conjac[0];i<n_conjac[1]; ++i){
+        ierr = MatSetValue(J, i, i, 0.0, INSERT_VALUES);CHKERRQ(ierr);
+    }
+    /* finish up jacobian */
+    ierr = MatAssemblyBegin(J,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+    ierr = MatAssemblyEnd(J,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+    /* Set residual and jacobian functions */
+    ierr = SNESSetFunction(snes, r, FormFunction, &sol_ctx);CHKERRQ(ierr);
+    ierr = SNESSetJacobian(snes, J, J, FormJacobian, &sol_ctx);CHKERRQ(ierr);
+    /* Default solver setup override from CL later*/
+    ierr = SNESSetType(snes, DEFAULT_SNES);CHKERRQ(ierr);
+    ierr = SNESGetKSP(snes, &ksp);CHKERRQ(ierr);
+    ierr = SNESGetLineSearch(snes, &linesearch);CHKERRQ(ierr);
+    ierr = SNESLineSearchSetType(linesearch, SNESLINESEARCHBT);
+    ierr = KSPGetPC(ksp,&pc);CHKERRQ(ierr);
+    ierr = PCSetType(pc,DEFAULT_PC);CHKERRQ(ierr);
+    ierr = PCFactorSetMatSolverType(pc, DEFAULT_LINEAR_PACK);CHKERRQ(ierr);
+    ierr = PCFactorReorderForNonzeroDiagonal(pc, 1e-10);CHKERRQ(ierr);
+    ierr = KSPSetType(ksp,DEFAULT_KSP);CHKERRQ(ierr);
+    ierr = SNESSetTolerances(snes, DEFAULT_SNES_ATOL, DEFAULT_SNES_RTOL,
+          0, DEFAULT_SNES_MAX_IT, DEFAULT_SNES_MAX_FUNC);CHKERRQ(ierr);
+    ierr = KSPSetTolerances(
+          ksp,DEFAULT_KSP_ATOL,DEFAULT_KSP_RTOL,PETSC_DEFAULT,200);CHKERRQ(ierr);
+    /* Read command line options for solver */
+    ierr = SNESSetFromOptions(snes);CHKERRQ(ierr);
+    /* Make x vec set initial guess from nl file, also get lb and ub */
+    ierr = VecGetArray(x,&xx);CHKERRQ(ierr);
+    ierr = VecGetArray(xl,&xxl);CHKERRQ(ierr);
+    ierr = VecGetArray(xu,&xxu);CHKERRQ(ierr);
+    for(i=0;i<n_var;++i){
+        xx[i] = X0[i]*sol_ctx.opt.ptest; //ptest is usually 1.0 could be differnt to test solver
+        xxl[i] = LUv[i]; //lower bound
+        xxu[i] = Uvx[i]; //upper bound
+    }
+    ierr = VecRestoreArray(x,&xx);CHKERRQ(ierr);
+    ierr = VecRestoreArray(x,&xxl);CHKERRQ(ierr);
+    ierr = VecRestoreArray(x,&xxu);CHKERRQ(ierr);
+    /* Set upper and lower bound most solver don't like but a few can use
+       if you include bounds and solver can't use will cause failure */
+    if(sol_ctx.opt.use_bounds) ierr = SNESVISetVariableBounds(snes, xl, xu);CHKERRQ(ierr);
+    /* Solve it */
+    ierr = SNESSolve(snes, NULL, x);CHKERRQ(ierr);
+    ierr = SNESGetConvergedReason(snes, &cr); CHKERRQ(ierr);
+    ierr = SNESGetIterationNumber(snes, &its);CHKERRQ(ierr);
+    /* Get the results */
+    ierr = VecGetArray(x, &xx);CHKERRQ(ierr);
+    /* If duing the perturb test compare to intial values from nl file */
+    if(sol_ctx.opt.per_test){
+        PetscPrintf(PETSC_COMM_SELF, "Perturb test result, showing differences from initial > 1e-6\n");
+        for(i=0;i<n_var;++i) if(xx[i] - X0[i] > 1e-6){
+            PetscPrintf(PETSC_COMM_SELF, "v%d - %e, %e, %e\n",i, xx[i], X0[i], xx[i] - X0[i]);
+        }
+    }
+    /* write the AMPL solution file */
+    PetscPrintf(PETSC_COMM_SELF, "SNESConvergedReason = %d, in %d iterations\n", cr, its);
+    get_snes_sol_message(msg, cr, sol_ctx.asl);
+    write_sol(msg, (real*)xx, NULL, NULL);
+    ierr = VecRestoreArray(x,&xx);CHKERRQ(ierr);
+    ierr = VecDestroy(&xl);CHKERRQ(ierr);
+    ierr = VecDestroy(&xu);CHKERRQ(ierr);
+    ierr = SNESDestroy(&snes);CHKERRQ(ierr); // ksp and pc are part of this
+  } //end snes solve
+
+  /* Should free stuff, but program ending anyway, so what's the point? */
+  ASL_free(&asl);
+  ierr = VecDestroy(&x);CHKERRQ(ierr);
+  ierr = VecDestroy(&r);CHKERRQ(ierr);
+  ierr = MatDestroy(&J);CHKERRQ(ierr);
+  ierr = PetscFinalize(); //All done with PETSc
+  return P_EXIT_NORMAL;
+}
+
+char **transform_args(int argc, char** argv, int *size){
+  /* change the format of the command line arguments from ASL to PETSc*/
+  const int max_args=200, max_arg_len=200;
+  char argv2[max_args][max_arg_len]; // buffer for reformatted args
+  char **argv3;
+  int argc2 = argc; //reformatted number of args
+  int i=0, j=0, k=0, h=0; // another counter
+
+  for(i=0; i<argc; ++i){
+    for(j=0;argv[i][j]!='\0';++j){
+      if(argv[i][j]==' '||argv[i][j]=='\t'||argv[i][j]=='\n'){} //strip white spc
+      else if(argv[i][j]=='='){ // split on '=''
+        h=0;
+        ++k;
+      }
+      else{
+        argv2[k][h] = argv[i][j]; //keep anything else
+        ++h;
+      }
+    }
+    ++k; //on to next arg
+    h=0;
+  }
+  argc2 = k;
+  argv3 = (char**)malloc(sizeof(char*)*argc2);
+  for(i=0; i<argc2; ++i){
+    argv3[i] = (char*)malloc(sizeof(char)*(strlen(argv2[i])+2));
+    memcpy(argv3[i], argv2[i], sizeof(char)*(strlen(argv2[i])+2));
+  }
+  *size = argc2;
+  return argv3;
+}
+
+void sol_ctx_init(Solver_ctx *ctx){
+  //Initialize some values in the solver context struct
+  ctx->dae_map_t=-1;  //ASL index of time variable (-1 for none)
+  ctx->n_var_diff=0; //DAE number of differential vars
+  ctx->n_var_deriv=0; //DAE number of derivative vars
+  ctx->n_var_state=0; //DAE number of state vars
+  ctx->n_var_alg=0;  //DAE number of algebraic variables
+  ctx->n_ineq=0;  // Number of inequality constraints
+  ctx->explicit_time=0; //DAE includes time variable? 1=yes 0=no
+  ctx->dof=0; //degrees of freedom
+  ctx->opt.ptest=1.0; // method to scale equations
+  ctx->opt.eq_scale_method=EQ_SCALE_MAX_GRAD; // method to scale equations
+  ctx->opt.var_scale_method=VAR_SCALE_NONE; // method to scale variables
+}

--- a/petsc/petsc.h
+++ b/petsc/petsc.h
@@ -1,0 +1,127 @@
+/*
+AMPL solver interface for PETSc
+John Eslick
+*/
+#ifndef PETSC_H
+#define PETSC_H
+
+#include<asl.h>
+#undef filename
+#include<petscsnes.h>
+#include<petscts.h>
+
+#define MSG_BUF_SIZE 2000
+
+/* Define some default setting, all changable through options */
+#define DEFAULT_LINEAR_PACK MATSOLVERMUMPS   //be sure to build petsc with mumps
+#define DEFAULT_SNES SNESNEWTONLS // newton line search
+#define DEFAULT_PC PCLU        //LU decomposition direct solve
+#define DEFAULT_KSP KSPPREONLY //default preconditioner solves this so preonly
+#define DEFAULT_SNES_ATOL 1e-9
+#define DEFAULT_SNES_RTOL 1e-9
+#define DEFAULT_KSP_ATOL 1e-10
+#define DEFAULT_KSP_RTOL 1e-15
+#define DEFAULT_SNES_MAX_IT 2000
+#define DEFAULT_SNES_MAX_FUNC 50000
+
+#define COLOR_NORMAL  "\x1b[0m"
+#define COLOR_RED     "\x1b[31m"
+#define COLOR_GREEN   "\x1b[32m"
+
+/* Variable scaling methods */
+typedef enum{
+    VAR_SCALE_NONE = 0,
+    VAR_SCALE_USER = 1
+}VARSCALE_TYPE;
+
+/* Equation scaling methods */
+typedef enum{
+    EQ_SCALE_NONE = 0,
+    EQ_SCALE_MAX_GRAD = 1,
+    EQ_SCALE_MAX_MULTIGRAD = 2, //not ready yet
+    EQ_SCALE_USER = 3
+}EQSCALE_TYPE;
+
+typedef enum{  //keep these under 50 and shouldn't confilict with PETSc codes
+   P_EXIT_NORMAL = 0, //Finished okay (solved is another matter)
+   P_EXIT_INTEGER = 1, //Exited due to integer variables
+   P_EXIT_DOF = 2, //Exited on DOF != 0
+   P_EXIT_INEQ = 3, //Exited on inequalities
+   P_EXIT_NO_NL_FILE_ERROR = 5, //Exited due to file not specified
+   P_EXIT_NL_FILE_ERROR = 6, //Exited due to nl file didn't read right
+   P_EXIT_DOF_DAE = 7, //DOF wrong for DAE problem
+   P_EXIT_VAR_DAE_MIS = 8, //number of derivatives mismatch
+   P_EXIT_MULTIPLE_TIME = 9 //more than on time variable
+}P_EXIT_CODES;
+
+typedef struct{
+  PetscMPIInt    mpi_size; // Number of processors (should be 1 for now)
+  PetscBool      show_cl; //show the command line, and transformed CL
+  char           stub[PETSC_MAX_PATH_LEN]; // File name (with or without ext)
+  char           typ_file[PETSC_MAX_PATH_LEN]; // output file with DAE types
+  fint           stublen; // Stub string length
+  PetscBool      got_stub;  // file stub was specified with -s
+  PetscBool      show_con;  // Option to show initial constraint values
+  PetscBool      show_init; // show initial values for x vec
+  PetscBool      show_jac;  // show jacobian at intial value
+  PetscBool      show_scale_factors;  // show jacobian at intial value
+  PetscScalar    scale_eq_jac_max; //Max jacobian entry for scaling
+  PetscScalar    scale_eq_fac_min; //Minimum scaling factor to use (overrides scale_eq_jac_max)
+  PetscBool      ampl_opt;  // -AMPL specified I catch it but ignore
+  PetscBool      per_test;  // perturb inital solved value and resolve  to test
+  PetscBool      use_bounds; // give solver variable bounds
+  PetscBool      scale_var; // scale the variables based on jacobian at init
+  PetscBool      scale_eq;  // scale the equations based on jacobian at init
+  PetscBool      dae_solve; //use dae solver (requires suffix information)
+  PetscBool      jac_explicit_diag; // explicitly include jacobian diagonal
+  EQSCALE_TYPE   eq_scale_method; // method to scale equations
+  VARSCALE_TYPE  var_scale_method; // method to scale variables
+  PetscScalar    ptest; // factor for perturb test
+}Solver_options;
+
+typedef struct{
+  ASL *asl; // ASL context
+  Solver_options opt; // command-line options
+  SufDesc *dae_suffix_var; // DAE suffixes on variables
+  SufDesc *dae_link_var; // DAE link derivatives to vars
+  SufDesc *scaling_factor_var; //user scale factors for vars
+  SufDesc *scaling_factor_con; //user scale factors for constraints
+  int dae_map_t; // ASL index of time variable (-1 for none)
+  int *dae_map_x; // PETSc index in x vec -> ASL index
+  int *dae_map_xdot; // PETSc index in xdot vec -> ASL index
+  int *dae_map_back; // ASL var index -> PETSc index (in x or xdot)
+  int *dae_link; // ASL index -> ASL index of linked derivative or differential var
+  int n_ineq; // Number of inequality constraints
+  int n_var_diff; //DAE number of differential vars
+  int n_var_deriv; //DAE number of derivative vars
+  int n_var_state; //DAE number of state vars
+  int n_var_alg;  //DAE number of algebraic variables
+  int explicit_time; //DAE includes time variable? 1=yes 0=no
+  int dof; // Degrees of freedom
+  FILE *nl; // nl-file pointer
+}Solver_ctx;
+
+/* Function prototypes (just stuffing everything in one file for now) */
+PetscErrorCode FormJacobian(SNES,Vec,Mat,Mat,void*);
+PetscErrorCode FormFunction(SNES,Vec,Vec,void*);
+PetscErrorCode FormDAEFunction(TS, PetscReal, Vec, Vec, Vec, void*);
+PetscErrorCode FormDAEJacobian(TS, PetscReal, Vec, Vec, PetscReal, Mat, Mat, void*);
+
+void get_dae_info(Solver_ctx *sol_ctx);
+void dae_var_map(Solver_ctx *sol_ctx);
+void sol_ctx_init(Solver_ctx *ctx);
+int get_snes_sol_message(char *msg, SNESConvergedReason term_reason, ASL *asl);
+int ScaleVars(Solver_ctx *sol_ctx);
+int ScaleVarsUser(Solver_ctx *sol_ctx);
+int ScaleEqs(Solver_ctx *sol_ctx);
+int ScaleEqs_Largest_Grad(Solver_ctx *sol_ctx);
+int ScaleEqsUser(Solver_ctx *sol_ctx);
+char **transform_args(int argc, char** argv, int *size);
+void print_commandline(const char* msg, int argc, char **argv);
+void print_x_asl(ASL *asl);
+void print_jac_asl(ASL *asl, real u, real l);
+void print_var_scale_factors_asl(ASL *asl);
+void print_con_scale_factors_asl(ASL *asl);
+void print_init_diagnostic(Solver_ctx *sol_ctx);
+
+#endif

--- a/petsc/printing.c
+++ b/petsc/printing.c
@@ -1,0 +1,75 @@
+#include"petsc.h"
+
+void print_commandline(const char* msg, int argc, char **argv){
+  /* print command line arguments */
+  int i=0;
+  PetscPrintf(PETSC_COMM_SELF, msg);
+  for(i=0; i<argc; ++i) PetscPrintf(PETSC_COMM_SELF, "%s ", argv[i]);
+  PetscPrintf(PETSC_COMM_SELF, "\n");
+}
+
+void print_init_diagnostic(Solver_ctx *sol_ctx){
+  if(sol_ctx->opt.show_jac){
+    print_jac_asl(sol_ctx->asl, 100, 1e-6);
+  }
+  if(sol_ctx->opt.show_init){
+    print_x_asl(sol_ctx->asl);
+  }
+  if(sol_ctx->opt.show_scale_factors){
+    print_var_scale_factors_asl(sol_ctx->asl);
+    print_con_scale_factors_asl(sol_ctx->asl);
+  }
+}
+
+void print_x_asl(ASL *asl){
+  int i=0;
+  char color_code[20];
+  PetscPrintf(PETSC_COMM_SELF, "Initial Values (scaled)\n");
+  for (i=0;i<n_var;++i){
+     if(X0[i] > Uvx[i] || X0[i] < LUv[i]){
+       memcpy(color_code, COLOR_RED, 15*sizeof(char));
+     }
+     else memcpy(color_code, COLOR_NORMAL, 15*sizeof(char));
+     PetscPrintf(PETSC_COMM_SELF, "%sv%d: %e <= %e <= %e%s\n",
+     color_code, i, LUv[i], X0[i], Uvx[i], COLOR_NORMAL);
+  }
+}
+
+void print_var_scale_factors_asl(ASL *asl){
+  int i;
+  if(asl->i.vscale!=NULL){
+    for(i=0;i<n_var;++i) printf("scale Factor v%d: %f\n", i, asl->i.vscale[i]);}
+}
+
+void print_con_scale_factors_asl(ASL *asl){
+  int i;
+  if(asl->i.cscale!=NULL){
+    for(i=0;i<n_con;++i) printf("scale factor c%d: %f\n", i, asl->i.cscale[i]);}
+}
+
+void print_jac_asl(ASL *asl, real u, real l){
+  /* Print sparse Jacobian  highlight elements over u or under l*/
+  cgrad          *cg;  /* sparse jacobian elements*/
+  real           *Jac; /* ASL test Jacobian */
+  char           color_code[20] = COLOR_NORMAL;
+  int            err;  /* Error code  from ASL fulctions */
+  int            i=0;
+
+  Jac = (real *)Malloc(nzc*sizeof(real)); /* Jacobian space */
+  jacval(X0, Jac, &err); /*calculate jacobian */
+  PetscPrintf(PETSC_COMM_SELF, "Computed Jacobian, err = %d\n", err);
+  PetscPrintf(PETSC_COMM_SELF, "Computed Jacobian values (scaled):\n");
+  for(i=n_conjac[0];i<n_conjac[1]; ++i){ /*i is constraint index */
+    cg = Cgrad[i];
+    PetscPrintf(PETSC_COMM_SELF, "c%d", i);
+    while(cg!=NULL){
+      if(fabs(Jac[cg->goff]) > u || fabs(Jac[cg->goff]) < l){
+        memcpy(color_code, COLOR_RED, 15*sizeof(char));}
+      else memcpy(color_code, COLOR_NORMAL, 15*sizeof(char));
+      PetscPrintf(PETSC_COMM_SELF, " %sv%d(%e)%s", color_code,cg->varno, Jac[cg->goff], COLOR_NORMAL);
+      cg=cg->next;
+    }
+    PetscPrintf(PETSC_COMM_SELF, "\n");
+  }
+  free(Jac);
+}

--- a/petsc/scale.c
+++ b/petsc/scale.c
@@ -1,0 +1,88 @@
+#include"petsc.h"
+
+int ScaleEqs(Solver_ctx *sol_ctx){
+    EQSCALE_TYPE method = sol_ctx->opt.eq_scale_method;
+    ASL *asl = sol_ctx->asl;
+    if(method==EQ_SCALE_NONE) return 0;
+    else if(method==EQ_SCALE_MAX_GRAD) return ScaleEqs_Largest_Grad(sol_ctx);
+    else if(method==EQ_SCALE_USER) return ScaleEqsUser(sol_ctx);
+    return 1;
+}
+
+int ScaleVars(Solver_ctx *sol_ctx){
+    VARSCALE_TYPE method = sol_ctx->opt.var_scale_method;
+    ASL *asl = sol_ctx->asl;
+    if(method==VAR_SCALE_NONE) return 0;
+    else if(method==VAR_SCALE_USER) return ScaleVarsUser(sol_ctx);
+    return 1;
+}
+
+int ScaleEqs_Largest_Grad(Solver_ctx *sol_ctx){
+    ASL *asl = sol_ctx->asl;
+    real s;
+    int i;
+    int err;
+    real A[nzc];
+    real jv, jv_max, jv_min;
+    cgrad *cg;
+
+    //Calculate jacobian values at intial point
+    jacval(X0,A,&err);
+    //Check the max partial derivatives of residuals
+    for(i=n_conjac[0];i<n_conjac[1]; ++i){ /*i is constraint index */
+        cg = Cgrad[i];
+        jv_max = 0.0;
+        while(cg!=NULL){
+            jv = fabs(A[cg->goff]);
+            if(jv > jv_max) jv_max = jv;
+            cg=cg->next;
+        }
+        if(jv_max > sol_ctx->opt.scale_eq_jac_max)
+          s = sol_ctx->opt.scale_eq_jac_max/jv_max;
+        else s = 1.0;
+        if(s < sol_ctx->opt.scale_eq_fac_min) s = sol_ctx->opt.scale_eq_fac_min;
+        conscale(i, s, &err);
+    }
+    return 0;
+}
+
+int ScaleEqsUser(Solver_ctx *sol_ctx){
+    ASL *asl = sol_ctx->asl;
+    int i = 0, err=0;
+    real s;
+
+    if (sol_ctx->scaling_factor_con->u.r == NULL) return 0; //no scaling factors provided
+    for(i=0;i<n_con;++i){ //n_con is asl vodoo incase you wonder where it came from
+      s = sol_ctx->scaling_factor_con->u.r[i];
+      conscale(i, s, &err); //if s is not provided, s is 0, conscale sets those to 1.0
+    }
+    return err;
+}
+
+int ScaleVarsUser(Solver_ctx *sol_ctx){
+    //Use scalling factors set in the scaling_factor suffix, for DAEs ignore
+    //scaling on the derivatives and use scaling from the differntial vars
+    //instead varaibles and there derivatives should be scaled the same
+    int i = 0, err=0;
+    real s;
+    ASL *asl = sol_ctx->asl;
+    if (sol_ctx->scaling_factor_var->u.r == NULL) return 0; //no scaling factors provided
+    if(sol_ctx->opt.dae_solve){ //dae so match scaling on derivatives
+      for(i=0;i<n_var;++i){ //n_var is asl vodoo incase you wonder where it came from
+        s = sol_ctx->scaling_factor_var->u.r[i];
+        if(sol_ctx->dae_suffix_var->u.i[i] == 2){
+          if(s == 0.0) s = 1.0;
+          else s = sol_ctx->scaling_factor_var->u.r[sol_ctx->dae_link[i]];
+        }
+        else if(sol_ctx->dae_suffix_var->u.i[i] == 3) s = 0.0; //can't scale time
+        varscale(i, s, &err); //if s is not provided, s is 0, varscale sets those to 1.0
+      }
+    }
+    else{ // no dae so use scale factors given
+      for(i=0;i<n_var;++i){ //n_var is asl vodoo incase you wonder where it came from
+        s = sol_ctx->scaling_factor_var->u.r[i];
+        varscale(i, s, &err); //if s is not provided, s is 0, varscale sets those to 1.0
+      }
+    }
+    return err;
+}

--- a/src/cubic/cubic_roots.h
+++ b/src/cubic/cubic_roots.h
@@ -31,11 +31,12 @@ static const double sqrt_3=1.73205080756888; //square root of 3
 typedef enum{ // Equations of state
     EOS_PR = 0,
     EOS_SRK = 1,
-    EOS_END = 2
+    EOS_VDW = 2,
+    EOS_END = 3
 }eos_indx;
 
-static const double eos_u[EOS_END] = {+2.0, +1.0};
-static const double eos_w[EOS_END] = {-1.0, +0.0};
+static const double eos_u[EOS_END] = {+2.0, +1.0, +0.0};
+static const double eos_w[EOS_END] = {-1.0, +0.0, +0.0};
 
 static const char liquid = 0;
 static const char vapor = 1;


### PR DESCRIPTION
This doesn't add petsc amlp solver build yet.  Just makes PETSc available in the build containers.

1. Add van der Waals option to cubic root finder code (#110)
2. Add petsc AMPL solver wrapper code.
3. Add PETSc builds to Linux build-platform docker files (except Centos 6 #108)