### PR TITLE
For PETSc build also pull in a couple python files

### DIFF
--- a/petsc/Makefile
+++ b/petsc/Makefile
@@ -10,5 +10,8 @@ bindir = $(prefix)/bin
 petsc: petsc.o fg_nl.o fg_dae.o printing.o
 	${CLINKER} -o petsc petsc.o fg_nl.o fg_dae.o printing.o $(ASL_LIB) ${PETSC_LIB}
 
+py: petscpy
+	${PYTHON} get_petsc_py.py
+
 install: petsc
 	${CP} petsc ${bindir}

--- a/petsc/get_petsc_py.py
+++ b/petsc/get_petsc_py.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import json
+import shutil
+
+petsc_dir = os.environ["PETSC_DIR"]
+petsc_py = os.path.join(petsc_dir, "lib/petsc/bin/")
+
+sys.path.append(petsc_py)
+
+from petsc_conf import get_conf
+
+if __name__ == "__main__":
+    c = get_conf()
+    with open(os.path.join("petscpy","petsc_conf.json"), "w") as f:
+        json.dump(list(c), f)
+    for f in ["PetscBinaryIO.py", "PetscBinaryIOTrajectory.py"]:
+        shutil.copyfile(os.path.join(petsc_py, f), os.path.join(os.getcwd(), "petscpy", f))

--- a/petsc/petsc.c
+++ b/petsc/petsc.c
@@ -34,7 +34,7 @@ int main(int argc, char **argv){
   static SufDecl suftab[] = { // suffixes to read in
     //doc for this at https://ampl.com/netlib/ampl/solvers/README.suf
     {"dae_suffix", NULL, ASL_Sufkind_var}, //var kinds for DAE solver
-    {"dae_link",   NULL, ASL_Sufkind_var}, //link derivatives to vars
+    {"dae_link", NULL, ASL_Sufkind_var}, //link derivatives to vars
     {"scaling_factor", NULL, ASL_Sufkind_var|ASL_Sufkind_real}, //var scale factors
     {"scaling_factor", NULL, ASL_Sufkind_con|ASL_Sufkind_real} //constraint scale factors
   };

--- a/petsc/petscpy/petsc_conf.py
+++ b/petsc/petscpy/petsc_conf.py
@@ -1,0 +1,8 @@
+import os
+import json
+
+def get_conf():
+     pth = os.path.join(os.path.dirname(__file__), "petsc_conf.json")
+     with open(pth, "r") as fp:
+         cfg = tuple(json.load(fp))
+     return cfg

--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -335,8 +335,10 @@ then
   export PETSC_ARCH=""
   cd $IDAES_EXT/petsc
   make
+  make py
   mkdir $IDAES_EXT/dist-petsc
   cp petsc $IDAES_EXT/dist-petsc
+  cp -r petscpy $IDAES_EXT/dist-petsc
   cp ../dist-solvers/license.txt $IDAES_EXT/dist-petsc/license_petsc.txt
   cp ../dist-solvers/version_solvers.txt $IDAES_EXT/dist-petsc/version_petsc.txt
 fi

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-2.5.3 (DATE) (PLAT)
+2.5.4 (DATE) (PLAT)


### PR DESCRIPTION
This pulls in a couple PETSc python files to read binary data written by the solver.  It also provides an alternate method of reading in the build configuration, which is needed to properly read the binary data. 