### PR TITLE
Fix for differential vars without derivatives

### DIFF
--- a/petsc/fg_dae.c
+++ b/petsc/fg_dae.c
@@ -153,3 +153,40 @@ void get_dae_info(Solver_ctx *sol_ctx){
   sol_ctx->n_var_state = n_var - sol_ctx->n_var_deriv - sol_ctx->explicit_time;
   sol_ctx->n_var_alg = sol_ctx->n_var_state - sol_ctx->n_var_diff;
 }
+
+int get_ts_sol_message(char *msg, TSConvergedReason term_reason, ASL *asl){
+  //solve_result_num is an ASL macro.  I stole the code numbers from ipopt
+  //so at least I know pyomo will recognize them.  I havent found documentation
+  //yet.
+  if(term_reason==TS_CONVERGED_TIME){ //reached final time
+    strcpy(msg, "TS_CONVERGED_TIME");
+    solve_result_num = 2;}
+  else if(term_reason==TS_CONVERGED_EVENT){ //stopped due to event detection
+    strcpy(msg, "TS_CONVERGED_EVENT");
+    solve_result_num = 2;}
+  else if(term_reason==TS_CONVERGED_USER){ //stopped due to event detection
+    strcpy(msg, "TS_CONVERGED_USER");
+    solve_result_num = 2;}
+  else if(term_reason==TS_CONVERGED_ITS){ //maxed out allowed time steps
+    strcpy(msg, "TS_CONVERGED_ITS");
+    solve_result_num = 400;}
+  else if(term_reason==TS_CONVERGED_ITERATING){ //means it's still running
+      strcpy(msg, "TS_CONVERGED_ITERATING");
+      solve_result_num = 400;}
+  else if(term_reason==TS_DIVERGED_NONLINEAR_SOLVE){
+    strcpy(msg, "TS_DIVERGED_NONLINEAR_SOLVE");
+    solve_result_num = 300;}
+  else if(term_reason==TS_DIVERGED_STEP_REJECTED){
+    strcpy(msg, "TS_DIVERGED_STEP_REJECTED");
+    solve_result_num = 300;}
+  else if(term_reason==TSFORWARD_DIVERGED_LINEAR_SOLVE){
+    strcpy(msg, "TSFORWARD_DIVERGED_LINEAR_SOLVE");
+    solve_result_num = 300;}
+  else if(term_reason==TSADJOINT_DIVERGED_LINEAR_SOLVE){
+    strcpy(msg, "TSADJOINT_DIVERGED_LINEAR_SOLVE");
+    solve_result_num = 300;}
+  else{
+    strcpy(msg, "Unknown Error");
+    solve_result_num = 500;}
+  return solve_result_num;
+}

--- a/petsc/petsc.c
+++ b/petsc/petsc.c
@@ -268,6 +268,7 @@ int main(int argc, char **argv){
     if(sol_ctx.explicit_time) x_asl[sol_ctx.dae_map_t] = t;
     /* write the AMPL solution file */
     get_ts_sol_message(msg, cr, sol_ctx.asl);
+    PetscPrintf(PETSC_COMM_SELF, "TSConvergedReason = %s\n", msg);
     write_sol(msg, x_asl, NULL, NULL); // write ASL sol file
     ierr = TSDestroy(&ts);
   } //end ts solve
@@ -330,8 +331,8 @@ int main(int argc, char **argv){
     /* Get the results */
     ierr = VecGetArray(x, &xx);CHKERRQ(ierr);
     /* write the AMPL solution file */
-    PetscPrintf(PETSC_COMM_SELF, "SNESConvergedReason = %d, in %d iterations\n", cr, its);
     get_snes_sol_message(msg, cr, sol_ctx.asl);
+    PetscPrintf(PETSC_COMM_SELF, "SNESConvergedReason = %s, in %d iterations\n", msg, its);
     write_sol(msg, (real*)xx, NULL, NULL);
     ierr = VecRestoreArray(x,&xx);CHKERRQ(ierr);
     ierr = VecDestroy(&xl);CHKERRQ(ierr);

--- a/petsc/petsc.h
+++ b/petsc/petsc.h
@@ -115,6 +115,7 @@ void dae_var_map(Solver_ctx *sol_ctx);
 
 // get solver status for sol file
 int get_snes_sol_message(char *msg, SNESConvergedReason term_reason, ASL *asl);
+int get_ts_sol_message(char *msg, TSConvergedReason term_reason, ASL *asl);
 
 // Extra diagnostic printing functions.
 void print_commandline(const char* msg, int argc, char **argv);

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-2.5.4 (DATE) (PLAT)
+2.5.5 (DATE) (PLAT)


### PR DESCRIPTION
This fixes the case where there are variables labeled differential, but no derivative that goes with them.  This should be fine.  We'll just need to make sure we don't assume that a derivative exists if a differential variable does.  This also fixes missed variable bounds for TS solvers, in case somebody wants to use a bounded nonlinear solver.