### PR TITLE
Minor fixes for windows

### DIFF
--- a/docker/build-platform/build.sh
+++ b/docker/build-platform/build.sh
@@ -18,5 +18,5 @@ else
 fi
 
 cd "$flavor"
-docker build --no-cache -t "$image" .
+docker build -t "$image" .
 cd ..

--- a/docker/build-platform/windows/Dockerfile
+++ b/docker/build-platform/windows/Dockerfile
@@ -50,9 +50,10 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
   function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args; } \
   msys 'cd /c/repo/petsc-3.17.1 && make PETSC_DIR=/c/repo/petsc-3.17.1 PETSC_ARCH=arch-mswin-c-opt all'
-  msys 'cd /c/repo/petsc-3.17.1 && mkdir ../petsc-dist/include/mumps_libseq && cp ./arch-*/externalpackages/git.mumps/libseq/mpi.h ../petsc-dist/include/mumps_libseq/'
 
 SHELL ["C:\\msys64\\usr\\bin\\bash.exe", "-l", "-c"]
 RUN 'cd /c/repo/petsc-3.17.1 && mingw32-make PETSC_DIR=/c/repo/petsc-3.17.1 PETSC_ARCH=arch-mswin-c-opt all'
 RUN 'cd /c/repo/petsc-3.17.1 && /usr/bin/python config/install.py'
+RUN 'cd /c/repo/petsc-3.17.1 && mkdir ../petsc-dist/include/mumps_libseq && cp ./arch-*/externalpackages/git.mumps/libseq/mpi.h ../petsc-dist/include/mumps_libseq/'
+
 RUN cmd /c 'taskkill /F /FI "MODULES eq msys-2.0.dll"'

--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -186,7 +186,7 @@ cd Ipopt
   --with-mumps-lflags="-L$PETSC_DIR/lib -lmetis -ldmumps -lmumps_common -lmpiseq -lpord" \
   --with-mumps-cflags="-I$PETSC_DIR/include -I$PETSC_DIR/include/mumps_libseq" \
   --prefix=$IDAES_EXT/coinbrew/dist \
-  CFLAGS="-L$PETSC_DIR/lib -lmetis -ldmumps -lmumps_common -lmpiseq -lpord"
+  CFLAGS="-L$PETSC_DIR/lib -lgfortran -lmetis -ldmumps -lmumps_common -lmpiseq -lpord"
 make
 make install
 cd $IDAES_EXT/coinbrew
@@ -199,7 +199,7 @@ cd Ipopt_l1
   --with-mumps-lflags="-L$PETSC_DIR/lib -lmetis -ldmumps -lmumps_common -lmpiseq -lpord" \
   --with-mumps-cflags="-I$PETSC_DIR/include -I$PETSC_DIR/include/mumps_libseq" \
   --prefix=$IDAES_EXT/coinbrew/dist_l1 \
-  CFLAGS="-L$PETSC_DIR/lib -lmetis -ldmumps -lmumps_common -lmpiseq -lpord"
+  CFLAGS="-L$PETSC_DIR/lib -lgfortran -lmetis -ldmumps -lmumps_common -lmpiseq -lpord"
 make
 make install
 cd $IDAES_EXT/coinbrew
@@ -318,7 +318,7 @@ cd Ipopt_share
   --with-mumps-lflags="-L$PETSC_DIR/lib -lmetis -ldmumps -lmumps_common -lmpiseq -lpord" \
   --with-mumps-cflags="-I$PETSC_DIR/include -I$PETSC_DIR/include/mumps_libseq" \
   --prefix=$IDAES_EXT/coinbrew/dist-share \
-  CFLAGS="-L$PETSC_DIR/lib -lmetis -ldmumps -lmumps_common -lmpiseq -lpord"
+  CFLAGS="-L$PETSC_DIR/lib -lgfortran -lmetis -ldmumps -lmumps_common -lmpiseq -lpord"
 make
 make install
 cd $IDAES_EXT/coinbrew


### PR DESCRIPTION
There was an error in the Windows docker file to build extensions.  There is also a linking problem only on Windows with mumps undefined references to gfortran.  I added -lgfortran to the mumps cflags for Ipopt, and hopfully that will fix it.  I'm guessing that mumps is being linked before fortran or maybe fortran is not linked at all.