### PR TITLE
Make sure distributed libraries are relocatable

### DIFF
--- a/doc/build-local.md
+++ b/doc/build-local.md
@@ -1,0 +1,36 @@
+# Building IDAES binaries locally
+
+For testing purposes, it may be useful to build the binaries locally, i.e. not
+using the Docker build scripts. This is also necessary for the MacOS builds
+(see the MacOS section in `build.md` for more information).
+
+You can build locally by running the following scripts:
+
+- `scripts/compile_solvers.sh`: Compile solvers (including `k_aug`, `dot_sens`,
+`petsc`, and all solver-associated libraries).
+- `scripts/compile_libs.sh`: Compile shared libraries for external functions.
+
+It is recommended to perform an "out-of-source" build. This can be done by
+first running `scripts/build_directory.sh _build` from the top level of this
+repository. This copies source code, makefiles, patch files, and build scripts
+into the `_build` directory, where you will actually run the build.
+Move into the build directory with `cd _build`.
+
+The build scripts were not designed for local use, so there are a few gotchas:
+
+- We look for patch files in a specific location relative to the original
+working directory. I.e. you must run `compile_solvers.sh` from *one level above*
+the scripts directory in order for patches (e.g. `ipopt.pc.patch`) to be
+correctly applied.
+- `ipopt.pc.patch` assumes that `coinmumps` and `coinhsl` are listed as
+dependencies in the `ipopt.pc` file. If either is not found (i.e. we are
+compiling without HSL), the patch application will fail.
+- By default, Petsc is assumed to be installed in hard-coded, OS-dependent
+location. If you are compiling locally, you have probably installed it
+in your own preferred location. To override the default, set the `PETSC_DIR`
+environment variable to the location where you have installed Petsc.
+- If you have your own system-installed HSL libraries that are discoverable
+by the linker (i.e. `LD_LIBRARY_PATH` is set), the COIN-OR solvers will likely
+be able to find and link against them. In this case, you will see a
+`HSL Present: NO` message (as there was no `coinhsl.zip` in the parent of the
+working directory), but will likely still build HSL-enabled solvers.

--- a/doc/build.md
+++ b/doc/build.md
@@ -114,6 +114,26 @@ Test on clean VM for now, hopfully GitHub actions runners will be available soon
 
 There is a GitHub actions test.
 
+## Testing a non-default branch
+
+By default, the Docker driver scripts (`docker/build.sh` and `docker\build.ps1`)
+checkout the `main` branch of `https://github.com/idaes/idaes-ext.git` to use
+for the build process. To test a different branch, arguments can be provided
+to the Docker driver scripts. For example, to test the `ubuntu2204` build with
+a custom branch called `mybranch` on `user`'s fork, run
+```bash
+./build.sh ubuntu2204 https://github.com/user/idaes-ext.git mybranch
+```
+To test the Windows build, run
+```powershell
+.\build.ps1 windows --no-cache https://github.com/user/idaes-ext.git mybranch
+```
+Note that the second argument to `build.ps1` is interpreted as an argument
+to `docker build`, so to run with a custom branch and no such argument, run
+```powershell
+.\build.ps1 windows https://github.com/user/idaes-ext.git mybranch
+```
+
 ## Release Hashes
 
 Collect all the tar files for a release in the same directory.

--- a/docker/build-extensions/build.ps1
+++ b/docker/build-extensions/build.ps1
@@ -1,8 +1,19 @@
 $flavor = $args[0]
 $buildarg_1 = $args[1]  # just use this to pass in --no-cache or some such
 
-$repo = "https://github.com/idaes/idaes-ext.git"
-$branch = "main"
+# The 3rd and 4th arguments provided will be interpreted as repo and branch.
+# (If you don't want to use buildarg_1, just pass in an empty string.)
+$repo = $args[2]
+$branch = $args[3]
+
+# If repo and branch are not provided, use default values
+IF ($repo -eq $null){
+  $repo = "https://github.com/idaes/idaes-ext.git"
+}
+IF ($branch -eq $null){
+  $branch = "main"
+}
+
 $mname = "x86_64"
 
 IF ($flavor -eq "windows"){

--- a/docker/build-extensions/build.ps1
+++ b/docker/build-extensions/build.ps1
@@ -35,18 +35,12 @@ docker build --rm ${buildarg_1} --build-arg repo=${repo} --build-arg branch=${br
 Remove-Item extras -Recurse -Force -Confirm:$false
 docker run --name ${flavor}_build_tmp -dt ${flavor}_build_itmp:latest
 docker stop ${flavor}_build_tmp
-docker cp ${flavor}_build_tmp:${wdir}/idaes-ext/dist-lib/idaes-lib-${flavor}-${mname}.tar.gz .
+docker cp ${flavor}_build_tmp:${wdir}/idaes-ext/dist-functions/idaes-functions-${flavor}-${mname}.tar.gz .
 try{
-  docker cp ${flavor}_build_tmp:${wdir}/idaes-ext/dist-solvers/idaes-solvers-${flavor}-${mname}.tar.gz .
+  docker cp ${flavor}_build_tmp:${wdir}/idaes-ext/dist/idaes-solvers-${flavor}-${mname}.tar.gz .
 }
 catch{
   echo "Solvers were not built."
-}
-try{
-  docker cp ${flavor}_build_tmp:${wdir}/idaes-ext/dist-petsc/idaes-petsc-${flavor}-${mname}.tar.gz .
-}
-catch{
-  echo "PETSc was not built."
 }
 docker rm ${flavor}_build_tmp
 docker rmi ${flavor}_build_itmp

--- a/docker/build-extensions/build.sh
+++ b/docker/build-extensions/build.sh
@@ -37,9 +37,8 @@ docker exec "$flavor"_"$mname"_build_tmp sh -c "cd ${wdir}/idaes-ext && bash scr
 docker exec "$flavor"_"$mname"_build_tmp sh -c "cd ${wdir}/idaes-ext && bash scripts/compile_libs.sh ${flavor}"
 docker stop "$flavor"_"$mname"_build_tmp
 
-docker cp "$flavor"_"$mname"_build_tmp:"$wdir"/idaes-ext/dist-lib/idaes-lib-"$flavor"-"$mname".tar.gz .
-docker cp "$flavor"_"$mname"_build_tmp:"$wdir"/idaes-ext/dist-solvers/idaes-solvers-"$flavor"-"$mname".tar.gz .
-docker cp "$flavor"_"$mname"_build_tmp:"$wdir"/idaes-ext/dist-petsc/idaes-petsc-"$flavor"-"$mname".tar.gz .
+docker cp "$flavor"_"$mname"_build_tmp:"$wdir"/idaes-ext/dist-functions/idaes-functions-"$flavor"-"$mname".tar.gz .
+docker cp "$flavor"_"$mname"_build_tmp:"$wdir"/idaes-ext/dist/idaes-solvers-"$flavor"-"$mname".tar.gz .
 
 docker rm "$flavor"_"$mname"_build_tmp
 

--- a/docker/build-extensions/build.sh
+++ b/docker/build-extensions/build.sh
@@ -1,8 +1,21 @@
 flavor=$1
 mname=$2
 
-repo="https://github.com/idaes/idaes-ext.git"
-branch="main"
+repo=$3
+branch=$4
+if [ ! "$repo" ]; then
+    repo="https://github.com/idaes/idaes-ext.git"
+fi
+if [ ! "$branch" ]; then
+    branch="main"
+fi
+
+echo "build.sh script arguments:
+    OS: $flavor
+    Arch: $mname
+    Repo: $repo
+    Branch: $branch
+"
 
 if [ "$flavor" = "windows" ]; then
   image="idaes-ext-windows-build:latest"

--- a/scripts/compile_libs.sh
+++ b/scripts/compile_libs.sh
@@ -31,29 +31,31 @@ cd $IDAES_EXT
 
 # Collect files
 rm -rf ./dist-lib
-mkdir dist-lib
-cd dist-lib
-cp ../src/dist/*.so ./
+mkdir dist-lib dist-lib/lib
+#cd dist-lib
+cp ./src/dist/*.so ./dist-lib/lib/
 if [ ${osname} = "windows" ]; then
-  mv functions.so functions.dll
-  mv general_helmholtz_external.so general_helmholtz_external.dll
-  mv cubic_roots.so cubic_roots.dll
+  mv dist-lib/lib/functions.so dist-lib/lib/functions.dll
+  mv dist-lib/lib/general_helmholtz_external.so dist-lib/lib/general_helmholtz_external.dll
+  mv dist-lib/lib/cubic_roots.so dist-lib/lib/cubic_roots.dll
 fi
 if [ ${osname} = "darwin" ]; then
-  mv functions.so functions.dylib
-  mv general_helmholtz_external.so general_helmholtz_external.dylib
-  mv cubic_roots.so cubic_roots.dylib
+  mv dist-lib/lib/functions.so dist-lib/lib/functions.dylib
+  mv dist-lib/lib/general_helmholtz_external.so dist-lib/lib/general_helmholtz_external.dylib
+  mv dist-lib/lib/cubic_roots.so dist-lib/lib/cubic_roots.dylib
 fi
-cp ../license.txt ./license_lib.txt
-cp ../version.txt ./version_lib.txt
-mkdir ./helm_data
-cp ../src/dist/param_data/*.json ./helm_data/
-cp ../src/dist/param_data/*.nl ./helm_data/
-cp ../src/dist/param_data/*.py ./helm_data/
-sed s/"(DATE)"/`date +%Y%m%d-%H%M`/g version_lib.txt > tmp
+cp ./license.txt ./dist-lib/license_lib.txt
+cp ./version.txt ./dist-lib/version_lib.txt
+mkdir ./dist-lib/lib/helm_data
+cp ./src/dist/param_data/*.json ./dist-lib/lib/helm_data/
+cp ./src/dist/param_data/*.nl ./dist-lib/lib/helm_data/
+cp ./src/dist/param_data/*.py ./dist-lib/lib/helm_data/
+sed s/"(DATE)"/`date +%Y%m%d-%H%M`/g dist-lib/version_lib.txt > tmp
 sed s/"(PLAT)"/${osname}-${MNAME}/g tmp > tmp2
-mv tmp2 version_lib.txt
+mv tmp2 dist-lib/version_lib.txt
 rm tmp
 
 # here you pack files
-tar -czvf idaes-lib-${osname}-${MNAME}.tar.gz *
+cd dist-lib
+tar -czvf idaes-functions-${osname}-${MNAME}.tar.gz *
+cd $IDAES_EXT

--- a/scripts/compile_libs.sh
+++ b/scripts/compile_libs.sh
@@ -30,32 +30,32 @@ make
 cd $IDAES_EXT
 
 # Collect files
-rm -rf ./dist-lib
-mkdir dist-lib dist-lib/lib
-#cd dist-lib
-cp ./src/dist/*.so ./dist-lib/lib/
+rm -rf ./dist-functions
+mkdir dist-functions dist-functions/lib
+#cd dist-functions
+cp ./src/dist/*.so ./dist-functions/lib/
 if [ ${osname} = "windows" ]; then
-  mv dist-lib/lib/functions.so dist-lib/lib/functions.dll
-  mv dist-lib/lib/general_helmholtz_external.so dist-lib/lib/general_helmholtz_external.dll
-  mv dist-lib/lib/cubic_roots.so dist-lib/lib/cubic_roots.dll
+  mv dist-functions/lib/functions.so dist-functions/lib/functions.dll
+  mv dist-functions/lib/general_helmholtz_external.so dist-functions/lib/general_helmholtz_external.dll
+  mv dist-functions/lib/cubic_roots.so dist-functions/lib/cubic_roots.dll
 fi
 if [ ${osname} = "darwin" ]; then
-  mv dist-lib/lib/functions.so dist-lib/lib/functions.dylib
-  mv dist-lib/lib/general_helmholtz_external.so dist-lib/lib/general_helmholtz_external.dylib
-  mv dist-lib/lib/cubic_roots.so dist-lib/lib/cubic_roots.dylib
+  mv dist-functions/lib/functions.so dist-functions/lib/functions.dylib
+  mv dist-functions/lib/general_helmholtz_external.so dist-functions/lib/general_helmholtz_external.dylib
+  mv dist-functions/lib/cubic_roots.so dist-functions/lib/cubic_roots.dylib
 fi
-cp ./license.txt ./dist-lib/license_lib.txt
-cp ./version.txt ./dist-lib/version_lib.txt
-mkdir ./dist-lib/lib/helm_data
-cp ./src/dist/param_data/*.json ./dist-lib/lib/helm_data/
-cp ./src/dist/param_data/*.nl ./dist-lib/lib/helm_data/
-cp ./src/dist/param_data/*.py ./dist-lib/lib/helm_data/
-sed s/"(DATE)"/`date +%Y%m%d-%H%M`/g dist-lib/version_lib.txt > tmp
+cp ./license.txt ./dist-functions/license_lib.txt
+cp ./version.txt ./dist-functions/version_lib.txt
+mkdir ./dist-functions/lib/helm_data
+cp ./src/dist/param_data/*.json ./dist-functions/lib/helm_data/
+cp ./src/dist/param_data/*.nl ./dist-functions/lib/helm_data/
+cp ./src/dist/param_data/*.py ./dist-functions/lib/helm_data/
+sed s/"(DATE)"/`date +%Y%m%d-%H%M`/g dist-functions/version_lib.txt > tmp
 sed s/"(PLAT)"/${osname}-${MNAME}/g tmp > tmp2
-mv tmp2 dist-lib/version_lib.txt
+mv tmp2 dist-functions/version_lib.txt
 rm tmp
 
 # here you pack files
-cd dist-lib
+cd dist-functions
 tar -czvf idaes-functions-${osname}-${MNAME}.tar.gz *
 cd $IDAES_EXT

--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -387,7 +387,7 @@ cp -r ./coinbrew/dist-share ./dist-share
 # Patch to remove "Requires.private: coinhsl coinmumps"
 # Note that we are patching the file *after* we copy it into the directory
 # we will distribute.
-patch ./dist-share/lib/pkgconfig/ipopt.pc < $IDAES_EXT/scripts/ipopt.pc.patch
+patch dist-share/lib/pkgconfig/ipopt.pc < $IDAES_EXT/scripts/ipopt.pc.patch
 # Subsequent parts of this script rely on being in this directory
 cd $IDAES_EXT/dist-solvers
 

--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -17,6 +17,8 @@ fi
 export MNAME=`uname -m`
 
 # Get path of directory we're working in
+# Note that, when accessing patch files, we assume this directory
+# to be the root of the idaes-ext repository.
 export IDAES_EXT=`pwd`
 
 if [ -f $IDAES_EXT/../coinhsl.zip ]
@@ -382,6 +384,10 @@ strip --strip-unneeded *
 # into ./dist-share. We will compress them and copy into ./dist-solvers later.
 cd ../
 cp -r ./coinbrew/dist-share ./dist-share
+# Patch to remove "Requires.private: coinhsl coinmumps"
+# Note that we are patching the file *after* we copy it into the directory
+# we will distribute.
+patch ./dist-share/lib/pkgconfig/ipopt.pc < $IDAES_EXT/scripts/ipopt.pc.patch
 # Subsequent parts of this script rely on being in this directory
 cd $IDAES_EXT/dist-solvers
 

--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -41,13 +41,19 @@ export CC="gcc"
 export CXX="g++"
 
 # set PETSc location
-if [ ${osname} = "windows" ]
-then
-  export PETSC_DIR=/c/repo/petsc-dist
-elif [ ${osname} = "darwin" ]; then
-  export PETSC_DIR="$HOME/src/petsc-dist"
-else
-  export PETSC_DIR=/repo/petsc-dist
+# These petsc environment variables are used by the makefile
+# in the $IDAES_EXT/petsc subdirectory.
+if [ -z $PETSC_DIR ]; then
+    # We only set PETSC_DIR if it is not already set. This is useful when
+    # running this script locally (i.e. not via Docker)
+    if [ ${osname} = "windows" ]
+    then
+      export PETSC_DIR=/c/repo/petsc-dist
+    elif [ ${osname} = "darwin" ]; then
+      export PETSC_DIR="$HOME/src/petsc-dist"
+    else
+      export PETSC_DIR=/repo/petsc-dist
+    fi
 fi
 export PETSC_ARCH=""
 

--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -54,6 +54,8 @@ if [ -z $PETSC_DIR ]; then
     else
       export PETSC_DIR=/repo/petsc-dist
     fi
+    echo "PETSC_DIR has been set to $PETSC_DIR. If this is incorrect, set"
+    echo "the PETSC_DIR environment variable before running this script."
 fi
 export PETSC_ARCH=""
 

--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -546,7 +546,7 @@ echo "#########################################################################"
 echo "# Finish                                                                #"
 echo "#########################################################################"
 cd dist
-tar -czvf idaes-extensions-${osname}-${MNAME}.tar.gz *
+tar -czvf idaes-solvers-${osname}-${MNAME}.tar.gz *
 cd $IDAES_EXT
 echo "Done"
 echo "HSL Present: ${with_hsl}"

--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -342,65 +342,69 @@ make $PARALLEL
 make install
 cd $IDAES_EXT/coinbrew
 
+# The above compiles and installs solvers into ./coinbrew/dist*
+# Now we will copy the files we wish to distribute into a ./dist directory,
+# with standard bin, include, and lib sub-directories.
+
 echo "#########################################################################"
-echo "# Copy Coin Solver Files to dist-solvers                                #"
+echo "# Copy Coin Solver Files to dist                                        #"
 echo "#########################################################################"
 cd $IDAES_EXT
-mkdir dist-solvers
-cd dist-solvers
+mkdir dist dist/bin dist/include dist/lib
+# I'll try to avoid cd-ing around, for now, to make this script more
+# explicit for the reader.
+# cd dist
 # Executables
 if [ ${osname} = "windows" ]; then
   # windows
-  cp ../coinbrew/dist_l1/bin/ipopt.exe ./ipopt_l1.exe
-  cp ../coinbrew/dist_l1/bin/ipopt_sens.exe ./ipopt_sens_l1.exe
+  cp ./coinbrew/dist_l1/bin/ipopt.exe ./dist/bin/ipopt_l1.exe
+  cp ./coinbrew/dist_l1/bin/ipopt_sens.exe ./dist/bin/ipopt_sens_l1.exe
   # Explicitly only get ipopt so we don't get anything we shouldn't
-  cp ../coinbrew/dist-share/bin/libipopt*.dll ./
-  cp ../coinbrew/dist-share/bin/libsipopt*.dll ./
+  cp ./coinbrew/dist-share/bin/libipopt*.dll ./dist/lib/
+  cp ./coinbrew/dist-share/bin/libsipopt*.dll ./dist/lib/
 elif [ ${osname} = "darwin" ]; then
-  cp ../coinbrew/dist_l1/bin/ipopt ./ipopt_l1
-  cp ../coinbrew/dist_l1/bin/ipopt_sens ./ipopt_sens_l1
+  cp ./coinbrew/dist_l1/bin/ipopt ./dist/bin/ipopt_l1
+  cp ./coinbrew/dist_l1/bin/ipopt_sens ./dist/bin/ipopt_sens_l1
   # Explicitly only get ipopt so we don't get anything we shouldn't
-  cp ../coinbrew/dist-share/lib/libipopt*.dylib ./
-  cp ../coinbrew/dist-share/lib/libsipopt*.dylib ./
+  cp ./coinbrew/dist-share/lib/libipopt*.dylib ./dist/lib/
+  cp ./coinbrew/dist-share/lib/libsipopt*.dylib ./dist/lib/
 else
   # linux
-  cp ../coinbrew/dist_l1/bin/ipopt ./ipopt_l1
-  cp ../coinbrew/dist_l1/bin/ipopt_sens ./ipopt_sens_l1
+  cp ./coinbrew/dist_l1/bin/ipopt ./dist/bin/ipopt_l1/
+  cp ./coinbrew/dist_l1/bin/ipopt_sens ./dist/bin/ipopt_sens_l1
   # Explicitly only get ipopt so we don't get anything we shouldn't
-  cp ../coinbrew/dist-share/lib/libipopt*.so ./
-  cp ../coinbrew/dist-share/lib/libsipopt*.so ./
+  cp ./coinbrew/dist-share/lib/libipopt*.so ./dist/lib/
+  cp ./coinbrew/dist-share/lib/libsipopt*.so ./dist/lib/
 fi
-cp ../coinbrew/dist/bin/ipopt ./
-cp ../coinbrew/dist/bin/ipopt_sens ./
-cp ../coinbrew/dist/bin/clp ./
-cp ../coinbrew/dist/bin/cbc ./
-cp ../coinbrew/dist/bin/bonmin ./
-cp ../coinbrew/dist/bin/couenne ./
+cp ./coinbrew/dist/bin/ipopt ./dist/bin/
+cp ./coinbrew/dist/bin/ipopt_sens ./dist/bin/
+cp ./coinbrew/dist/bin/clp ./dist/bin/
+cp ./coinbrew/dist/bin/cbc ./dist/bin/
+cp ./coinbrew/dist/bin/bonmin ./dist/bin/
+cp ./coinbrew/dist/bin/couenne ./dist/bin/
 # Run strip to remove unneeded symbols (it's okay that some files
 #  aren't exe or libraries)
-strip --strip-unneeded *
+strip --strip-unneeded ./dist/bin/*
 
-# Copy the solver libraries and header files (just ipopt and sipopt for now)
-# into ./dist-share. We will compress them and copy into ./dist-solvers later.
-cd ../
-cp -r ./coinbrew/dist-share ./dist-share
+# Copy contents of dist-share (ipopt lib, include, and share) into dist
+cp -r ./coinbrew/dist-share/* ./dist/
+
 # Patch to remove "Requires.private: coinhsl coinmumps"
 # Note that we are patching the file *after* we copy it into the directory
 # we will distribute.
-patch dist-share/lib/pkgconfig/ipopt.pc < $IDAES_EXT/scripts/ipopt.pc.patch
-# Subsequent parts of this script rely on being in this directory
-cd $IDAES_EXT/dist-solvers
+patch ./dist/lib/pkgconfig/ipopt.pc < $IDAES_EXT/scripts/ipopt.pc.patch
 
 echo "#########################################################################"
 echo "# Copy License and Version Files to dist-solvers                        #"
 echo "#########################################################################"
 # Text information files include build time
-cp ../license.txt ./
-cp ../version.txt ./version_solvers.txt
-sed s/"(DATE)"/`date +%Y%m%d-%H%M`/g version_solvers.txt > tmp
-sed s/"(PLAT)"/${osname}-${MNAME}/g tmp > tmp2
-mv tmp2 version_solvers.txt
-rm tmp
+cp ./license.txt ./dist/
+cp ./version.txt ./dist/version_solvers.txt
+sed s/"(DATE)"/`date +%Y%m%d-%H%M`/g ./dist/version_solvers.txt > ./dist/tmp
+sed s/"(PLAT)"/${osname}-${MNAME}/g ./dist/tmp > ./dist/tmp2
+# Why do we create dist/version_solvers.txt above if we will just overwrite it?
+mv ./dist/tmp2 ./dist/version_solvers.txt
+rm ./dist/tmp*
 
 #
 # Copy some linked libraries from homebrew or mingw, covered by gcc runtime
@@ -412,25 +416,25 @@ echo "# Copy GCC/MinGW Runtime Libraries to dist-solvers                      #"
 echo "#########################################################################"
 if [ ${osname} = "windows" ]; then
     # Winodws MinGW linked redistributable libraries
-    cp /mingw64/bin/libstdc++-6.dll ./
-    cp /mingw64/bin/libgcc_s_seh-1.dll ./
-    cp /mingw64/bin/libwinpthread-1.dll ./
-    cp /mingw64/bin/libgfortran-*.dll ./
-    cp /mingw64/bin/libquadmath-0.dll ./
-    cp /mingw64/bin/libgomp-1.dll ./
-    cp /mingw64/bin/liblapack.dll ./
-    cp /mingw64/bin/libblas.dll ./
-    cp /mingw64/bin/libbz2-*.dll ./
-    cp /mingw64/bin/zlib*.dll ./
-    cp /mingw64/bin/libssp*.dll ./
+    cp /mingw64/bin/libstdc++-6.dll ./dist/lib/
+    cp /mingw64/bin/libgcc_s_seh-1.dll ./dist/lib/
+    cp /mingw64/bin/libwinpthread-1.dll ./dist/lib/
+    cp /mingw64/bin/libgfortran-*.dll ./dist/lib/
+    cp /mingw64/bin/libquadmath-0.dll ./dist/lib/
+    cp /mingw64/bin/libgomp-1.dll ./dist/lib/
+    cp /mingw64/bin/liblapack.dll ./dist/lib/
+    cp /mingw64/bin/libblas.dll ./dist/lib/
+    cp /mingw64/bin/libbz2-*.dll ./dist/lib/
+    cp /mingw64/bin/zlib*.dll ./dist/lib/
+    cp /mingw64/bin/libssp*.dll ./dist/lib/
 fi
 
 if [ ${osname} = "darwin" ]; then
-  cp ${BREWLIB}libgfortran.5.dylib ./
-  cp ${BREWLIB}libgcc_s.1.1.dylib ./
-  cp ${BREWLIB}libstdc++.6.dylib ./
-  cp ${BREWLIB}libgomp.1.dylib ./
-  cp ${BREWLIB}libquadmath.0.dylib ./
+  cp ${BREWLIB}libgfortran.5.dylib ./dist/lib/
+  cp ${BREWLIB}libgcc_s.1.1.dylib ./dist/lib/
+  cp ${BREWLIB}libstdc++.6.dylib ./dist/lib/
+  cp ${BREWLIB}libgomp.1.dylib ./dist/lib/
+  cp ${BREWLIB}libquadmath.0.dylib ./dist/lib/
 fi
 
 echo "#########################################################################"
@@ -442,7 +446,7 @@ if [ ${osname} = "darwin" ]; then
   export CXX="c++"
 fi
 
-cd $IDAES_EXT
+# We are already in this directory
 git clone $PYNU_REPO
 cd pyomo
 git checkout $PYNU_BRANCH
@@ -456,12 +460,13 @@ else
   cmake .. -DENABLE_HSL=no -DIPOPT_DIR=$IDAES_EXT/coinbrew/dist
 fi
 make $PARALLEL
-cp libpynumero_ASL* $IDAES_EXT/dist-solvers
+cp libpynumero_ASL* $IDAES_EXT/dist/lib/
+# Return to root directory
+cd $IDAES_EXT
 
 echo "#########################################################################"
 echo "# k_aug, dotsens                                                        #"
 echo "#########################################################################"
-cd $IDAES_EXT
 git clone $K_AUG_REPO
 cp ./scripts/k_aug_CMakeLists.txt ./k_aug/CMakeLists.txt
 cd k_aug
@@ -473,8 +478,10 @@ else
   cmake -DCMAKE_C_COMPILER=$CC .
 fi
 make $PARALLEL
-cp bin/k_aug* $IDAES_EXT/dist-solvers
-cp dot_sens* $IDAES_EXT/dist-solvers
+cp bin/k_aug* $IDAES_EXT/dist/bin/
+cp dot_sens* $IDAES_EXT/dist/bin/
+# Return to root directory
+cd $IDAES_EXT
 
 echo "#########################################################################"
 echo "# PETSc                                                                 #"
@@ -484,23 +491,21 @@ export ASL_LIB=$IDAES_EXT/coinbrew/dist/lib/libcoinasl.a
 cd $IDAES_EXT/petsc
 make $PARALLEL
 make py
-mkdir $IDAES_EXT/dist-petsc
 if [ ${osname} = "windows" ]
 then
-  cp petsc.exe $IDAES_EXT/dist-petsc
+  cp petsc.exe $IDAES_EXT/dist/bin/
 else
-  cp petsc $IDAES_EXT/dist-petsc
+  cp petsc $IDAES_EXT/dist/bin/
 fi
-cp -r petscpy $IDAES_EXT/dist-petsc
-cp ../dist-solvers/license.txt $IDAES_EXT/dist-petsc/license_petsc.txt
-cp ../dist-solvers/version_solvers.txt $IDAES_EXT/dist-petsc/version_petsc.txt
+cp -r petscpy $IDAES_EXT/dist/lib/
 
+# Return to root directory
+cd $IDAES_EXT
 
 if [ ${osname} = "darwin" ]; then
   echo "#########################################################################"
   echo "# macOS update rpaths                                                   #"
   echo "#########################################################################"
-  cd $IDAES_EXT/dist-solvers
   update_rpath_darwin() {
     install_name_tool -change ${BREWLIB}libgfortran.5.dylib @rpath/libgfortran.5.dylib $1
     install_name_tool -change ${BREWLIB}libgcc_s.1.1.dylib @rpath/libgcc_s.1.1.dylib $1
@@ -512,51 +517,36 @@ if [ ${osname} = "darwin" ]; then
   update_library_rpath_darwin() {
     install_name_tool -id @rpath/$1 $1
   }
-  update_rpath_darwin ipopt
-  update_rpath_darwin ipopt_sens
-  update_rpath_darwin clp
-  update_rpath_darwin cbc
-  update_rpath_darwin bonmin
-  update_rpath_darwin couenne  
-  update_rpath_darwin ipopt_l1
-  update_rpath_darwin ipopt_sens_l1
-  update_rpath_darwin libipopt.dylib
-  update_rpath_darwin libsipopt.dylib
-  update_rpath_darwin libipopt.3.dylib
-  update_rpath_darwin libsipopt.3.dylib
-  update_rpath_darwin libpynumero_ASL.dylib
-  update_library_rpath_darwin libipopt.dylib
-  update_library_rpath_darwin libsipopt.dylib
-  update_library_rpath_darwin libipopt.3.dylib
-  update_library_rpath_darwin libsipopt.3.dylib
-  update_library_rpath_darwin libpynumero_ASL.dylib
+  update_rpath_darwin dist/bin/ipopt
+  update_rpath_darwin dist/bin/ipopt_sens
+  update_rpath_darwin dist/bin/clp
+  update_rpath_darwin dist/bin/cbc
+  update_rpath_darwin dist/bin/bonmin
+  update_rpath_darwin dist/bin/couenne  
+  update_rpath_darwin dist/bin/ipopt_l1
+  update_rpath_darwin dist/bin/ipopt_sens_l1
+  update_rpath_darwin dist/lib/libipopt.dylib
+  update_rpath_darwin dist/lib/libsipopt.dylib
+  update_rpath_darwin dist/lib/libipopt.3.dylib
+  update_rpath_darwin dist/lib/libsipopt.3.dylib
+  update_rpath_darwin dist/lib/libpynumero_ASL.dylib
+  update_library_rpath_darwin dist/lib/libipopt.dylib
+  update_library_rpath_darwin dist/lib/libsipopt.dylib
+  update_library_rpath_darwin dist/lib/libipopt.3.dylib
+  update_library_rpath_darwin dist/lib/libsipopt.3.dylib
+  update_library_rpath_darwin dist/lib/libpynumero_ASL.dylib
   # if no hsl k_aug and dot_snse won't exist
-  update_rpath_darwin k_aug || true 
-  update_rpath_darwin dot_sens || true
-  cd $IDAES_EXT/dist-petsc
-  update_rpath_darwin petsc
-  # Update rpaths in dist-share/lib
-  cd $IDAES_EXT/dist-share/lib
-  update_rpath_darwin libipopt.dylib
-  update_rpath_darwin libsipopt.dylib
-  update_rpath_darwin libipopt.3.dylib
-  update_rpath_darwin libsipopt.3.dylib
-  update_library_rpath_darwin libipopt.dylib
-  update_library_rpath_darwin libsipopt.dylib
-  update_library_rpath_darwin libipopt.3.dylib
-  update_library_rpath_darwin libsipopt.3.dylib
+  update_rpath_darwin dist/bin/k_aug || true 
+  update_rpath_darwin dist/bin/dot_sens || true
+  update_rpath_darwin dist/bin/petsc
 fi
 
 # here you pack files
 echo "#########################################################################"
 echo "# Finish                                                                #"
 echo "#########################################################################"
-cd $IDAES_EXT/dist-petsc
-tar -czvf idaes-petsc-${osname}-${MNAME}.tar.gz *
-cd $IDAES_EXT/dist-share
-tar -czvf idaes-local-${osname}-${MNAME}.tar.gz *
-cd $IDAES_EXT/dist-solvers
-cp ../dist-share/idaes-local-${osname}-${MNAME}.tar.gz ./
-tar -czvf idaes-solvers-${osname}-${MNAME}.tar.gz *
+cd dist
+tar -czvf idaes-extensions-${osname}-${MNAME}.tar.gz *
+cd $IDAES_EXT
 echo "Done"
 echo "HSL Present: ${with_hsl}"

--- a/scripts/ipopt.pc.patch
+++ b/scripts/ipopt.pc.patch
@@ -1,0 +1,8 @@
+--- coinbrew/dist-share/lib/pkgconfig/ipopt.pc	2023-10-03 15:21:44
++++ coinbrew/dist-share/lib/pkgconfig/ipopt.pc.fix	2023-10-06 11:38:08
+@@ -12,4 +12,4 @@
+ Libs.private:   -framework Accelerate  -ldl
+ Cflags: -I${includedir}
+ Requires:
+-Requires.private: coinhsl coinmumps 
++#Requires.private: coinhsl coinmumps 

--- a/scripts/mac_collect.sh
+++ b/scripts/mac_collect.sh
@@ -1,3 +1,2 @@
 mv ./dist-solvers/idaes-solvers-darwin-arm64.tar.gz ./idaes-solvers-darwin-aarch64.tar.gz
-mv ./dist-lib/idaes-lib-darwin-arm64.tar.gz ./idaes-lib-darwin-aarch64.tar.gz
-mv ./dist-petsc/idaes-petsc-darwin-arm64.tar.gz ./idaes-petsc-darwin-aarch64.tar.gz
+mv ./dist-lib/idaes-functions-darwin-arm64.tar.gz ./idaes-lib-darwin-aarch64.tar.gz

--- a/scripts/mac_collect.sh
+++ b/scripts/mac_collect.sh
@@ -1,2 +1,2 @@
-mv ./dist-solvers/idaes-solvers-darwin-arm64.tar.gz ./idaes-solvers-darwin-aarch64.tar.gz
-mv ./dist-lib/idaes-functions-darwin-arm64.tar.gz ./idaes-lib-darwin-aarch64.tar.gz
+mv ./dist/idaes-solvers-darwin-arm64.tar.gz ./idaes-solvers-darwin-aarch64.tar.gz
+mv ./dist-functions/idaes-functions-darwin-arm64.tar.gz ./idaes-functions-darwin-aarch64.tar.gz

--- a/scripts/mac_collect_x86_64.sh
+++ b/scripts/mac_collect_x86_64.sh
@@ -1,3 +1,2 @@
-mv ./dist-solvers/idaes-solvers-darwin-x86_64.tar.gz ./idaes-solvers-darwin-x86_64.tar.gz
-mv ./dist-lib/idaes-lib-darwin-x86_64.tar.gz ./idaes-lib-darwin-x86_64.tar.gz
-mv ./dist-petsc/idaes-petsc-darwin-x86_64.tar.gz ./idaes-petsc-darwin-x86_64.tar.gz
+mv ./dist/idaes-solvers-darwin-x86_64.tar.gz ./idaes-solvers-darwin-x86_64.tar.gz
+mv ./dist-functions/idaes-functions-darwin-x86_64.tar.gz ./idaes-functions-darwin-x86_64.tar.gz


### PR DESCRIPTION
- Use the `--enable-relocatable` flag when configuing Ipopt to make sure the `ipopt.pc` file uses relative paths
- Add an `install_name_tool` step on Darwin to define library names with `@rpath`
- Compress the idaes-local tar file _after_ install names have been updated (only relevant for Darwin)

With these changes, I believe a user will still need the following steps to link against our IDAES libraries:
- `export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$HOME/.idaes/lib/pkgconfig"`
- `export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:/$HOME/.idaes/lib`
- Patch `.idaes/lib/pkgconfig/ipopt.pc` to comment out the `Requires.private: coinhsl coinmumps` line

We could apply a patch in `compile_solvers.sh` to comment out the "Requires.private" line in ipopt.pc, but it would be nice if we could somehow compile Ipopt such that these requirements (which don't seem to actually be necessary) are not included.