### PR TITLE
Update Windows test Python version

### DIFF
--- a/.github/workflows/test_windows_main.yml
+++ b/.github/workflows/test_windows_main.yml
@@ -6,10 +6,10 @@ jobs:
   test:
     runs-on: windows-latest
     steps:
-      - name: Set up Python 3.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.10'
       - name: "Clone/Install IDAES-PSE"
         shell: cmd
         run: |


### PR DESCRIPTION
This was hand-coded to 3.7, which we no longer support. Here I propose updating to 3.10.