### PR TITLE
Better support building without HSL

### DIFF
--- a/doc/build-local.md
+++ b/doc/build-local.md
@@ -20,17 +20,16 @@ The build scripts were not designed for local use, so there are a few gotchas:
 
 - We look for patch files in a specific location relative to the original
 working directory. I.e. you must run `compile_solvers.sh` from *one level above*
-the scripts directory in order for patches (e.g. `ipopt.pc.patch`) to be
+the scripts directory in order for patches (e.g. `CouenneMatrix.hpp.patch`) to be
 correctly applied.
-- `ipopt.pc.patch` assumes that `coinmumps` and `coinhsl` are listed as
-dependencies in the `ipopt.pc` file. If either is not found (i.e. we are
-compiling without HSL), the patch application will fail.
 - By default, Petsc is assumed to be installed in hard-coded, OS-dependent
 location. If you are compiling locally, you have probably installed it
 in your own preferred location. To override the default, set the `PETSC_DIR`
 environment variable to the location where you have installed Petsc.
-- If you have your own system-installed HSL libraries that are discoverable
-by the linker (i.e. `LD_LIBRARY_PATH` is set), the COIN-OR solvers will likely
-be able to find and link against them. In this case, you will see a
-`HSL Present: NO` message (as there was no `coinhsl.zip` in the parent of the
-working directory), but will likely still build HSL-enabled solvers.
+- By default, we look for a `coinhsl.zip` file in the parent of the original
+working directory. If this file is not found, we attempt to compile Ipopt with an
+installed coinhsl library in a linker-accesible location. If no coinhsl library
+can be found (or compiled from source in `coinhsl.zip`), the `compile_solvers.sh`
+script will fail attempting to build `k_aug`, which cannot be built without HSL.
+To avoid this failure, send the `--without-hsl` argument to `compile_solvers.sh`
+after the OS name.

--- a/doc/build.md
+++ b/doc/build.md
@@ -116,13 +116,14 @@ There is a GitHub actions test.
 
 ## Testing a non-default branch
 
-By default, the Docker driver scripts (`docker/build.sh` and `docker\build.ps1`)
+By default, the Docker driver scripts
+(`docker/build-extensions/build.sh` and `docker\build-extentions\build.ps1`)
 checkout the `main` branch of `https://github.com/idaes/idaes-ext.git` to use
 for the build process. To test a different branch, arguments can be provided
 to the Docker driver scripts. For example, to test the `ubuntu2204` build with
 a custom branch called `mybranch` on `user`'s fork, run
 ```bash
-./build.sh ubuntu2204 https://github.com/user/idaes-ext.git mybranch
+./build.sh ubuntu2204 x86_64 https://github.com/user/idaes-ext.git mybranch
 ```
 To test the Windows build, run
 ```powershell
@@ -141,3 +142,16 @@ Collect all the tar files for a release in the same directory.
 With IDAES installed, run ``idaes hash-extensions --path <path to tar files> --release <release>``
 A text file with the hash of all the files will be written to the directory with the
 release files.
+
+## Building without HSL
+
+For testing purposes, it may be useful to build for multiple operating systems
+(via Docker) without HSL. This may be accomplished by passing the `--without-hsl`
+argument to `docker/build-extensions/build.sh`, after the OS name, architecture name,
+repository URL, and repository branch.
+This fifth positional argument to `build.sh` is interpreted as an argument (or arguments)
+to send to `compile_solvers.sh`.
+For example:
+```bash
+./build.sh ubuntu2204 x86_64 https://github.com/IDAES/idaes-ext.git main --without-hsl
+```

--- a/docker/build-extensions/build.sh
+++ b/docker/build-extensions/build.sh
@@ -10,11 +10,14 @@ if [ ! "$branch" ]; then
     branch="main"
 fi
 
+solver_buildargs=$5
+
 echo "build.sh script arguments:
     OS: $flavor
     Arch: $mname
     Repo: $repo
     Branch: $branch
+    Args to compile_solvers.sh: $solver_buildargs
 "
 
 if [ "$flavor" = "windows" ]; then
@@ -46,7 +49,7 @@ docker cp ./extras/ "$flavor"_"$mname"_build_tmp:"$wdir"
 docker exec "$flavor"_"$mname"_build_tmp sh -c "cp ${wdir}/extras/* ${wdir}"
 docker exec "$flavor"_"$mname"_build_tmp sh -c "cd ${wdir}/extras && pwd"
 docker exec "$flavor"_"$mname"_build_tmp sh -c "cd ${wdir} && git clone ${repo} && cd idaes-ext && git checkout ${branch}"
-docker exec "$flavor"_"$mname"_build_tmp sh -c "cd ${wdir}/idaes-ext && bash scripts/compile_solvers.sh ${flavor}"
+docker exec "$flavor"_"$mname"_build_tmp sh -c "cd ${wdir}/idaes-ext && bash scripts/compile_solvers.sh ${flavor} ${solver_buildargs}"
 docker exec "$flavor"_"$mname"_build_tmp sh -c "cd ${wdir}/idaes-ext && bash scripts/compile_libs.sh ${flavor}"
 docker stop "$flavor"_"$mname"_build_tmp
 

--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -507,21 +507,25 @@ cd $IDAES_EXT
 echo "#########################################################################"
 echo "# k_aug, dotsens                                                        #"
 echo "#########################################################################"
-git clone $K_AUG_REPO
-cp ./scripts/k_aug_CMakeLists.txt ./k_aug/CMakeLists.txt
-cd k_aug
-git checkout $K_AUG_BRANCH
-if [ ${osname} = "windows" ]
-then
-  cmake -DWITH_MINGW=ON -DCMAKE_C_COMPILER=$CC -G"MSYS Makefiles" .
+if [ $with_hsl = "YES" ]; then
+  git clone $K_AUG_REPO
+  cp ./scripts/k_aug_CMakeLists.txt ./k_aug/CMakeLists.txt
+  cd k_aug
+  git checkout $K_AUG_BRANCH
+  if [ ${osname} = "windows" ]
+  then
+    cmake -DWITH_MINGW=ON -DCMAKE_C_COMPILER=$CC -G"MSYS Makefiles" .
+  else
+    cmake -DCMAKE_C_COMPILER=$CC .
+  fi
+  make $PARALLEL
+  cp bin/k_aug* $IDAES_EXT/dist/bin/
+  cp dot_sens* $IDAES_EXT/dist/bin/
+  # Return to root directory
+  cd $IDAES_EXT
 else
-  cmake -DCMAKE_C_COMPILER=$CC .
+  echo "Skipping k_aug and dot_sens as we are not using HSL"
 fi
-make $PARALLEL
-cp bin/k_aug* $IDAES_EXT/dist/bin/
-cp dot_sens* $IDAES_EXT/dist/bin/
-# Return to root directory
-cd $IDAES_EXT
 
 echo "#########################################################################"
 echo "# PETSc                                                                 #"

--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-# Exit on error.
-set -e
-
 # These scripts are not meant to be used for general builds.  They
 # are taylor only to specific build systems.  They may provide some
 # hints on how to build the solvers, but are limited.

--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -39,6 +39,7 @@ elif [ -f $IDAES_EXT/../coinhsl.zip ]; then
   build_hsl="YES"
 else
   echo "coinhsl.zip not found. Attempting to build with installed HSL." >&2
+  echo "To skip HSL-reliant build steps, send the --without-hsl argument to this script" >&2
   echo "HSL: YES"
   hslflag="--with-hsl"
   with_hsl="YES"

--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -26,19 +26,19 @@ export IDAES_EXT=`pwd`
 
 arg2=$2
 if [ $arg2 = "--without-hsl" ]; then
-  echo "--without-hsl flag received. Building solvers without HSL."
+  echo "--without-hsl flag received. Building solvers without HSL." >&2
   echo "HSL: NO"
   hslflag="--without-hsl"
   with_hsl="NO"
   build_hsl="NO"
 elif [ -f $IDAES_EXT/../coinhsl.zip ]; then
-  echo "coinhsl.zip found. Building solvers with HSL."
+  echo "coinhsl.zip found. Building solvers with HSL." >&2
   echo "HSL: YES"
   hslflag="--with-hsl"
   with_hsl="YES"
   build_hsl="YES"
 else
-  echo "coinhsl.zip not found. Attempting to build with installed HSL."
+  echo "coinhsl.zip not found. Attempting to build with installed HSL." >&2
   echo "HSL: YES"
   hslflag="--with-hsl"
   with_hsl="YES"
@@ -170,13 +170,6 @@ if [ -f $IDAES_EXT/../coinhsl.zip ]; then
   cd ThirdParty/HSL/coinhsl
   unzip coinhsl.zip
   cd $IDAES_EXT/coinbrew
-  # We have already printed a message about HSL
-  #echo "HSL is available, building with HSL"
-  #with_hsl="YES"
-#else
-#  # If the HSL isn't there, build without it.
-#  echo "HSL Not Available, BUILDING SOLVERS WITHOUT HSL" >&2
-#  with_hsl="NO"
 fi
 
 echo "#########################################################################"


### PR DESCRIPTION
### Summary
https://github.com/IDAES/idaes-ext/pull/266 adds `set -e`, which causes builds to fail if HSL is not present. This PR fixes these failures, and adds an option to explicitly turn off building with HSL (even if it is available as a local zip file or elsewhere).

### Changes
- If the second positional argument to `compile_solvers.sh` is `--without-hsl`, we will pass `--without-hsl` to Ipopt compile steps (regardless of whether or not HSL is available). We also skip building `k_aug` and `dot_sens`, as these fail without HSL
- If a local coinhsl.zip file is not found, and `--without-hsl` is **not** used, we explicitly notify the user that we are attempting to build with an already-installed HSL library (previously, we did this implicitly)
- In `docker/build-extensions/build.sh`, interpret the *fifth* positional argument as an argument (or arguments) to send to `compile_solvers.sh`. This allows us to use `--without-hsl` when using the (Linux) docker build script

Admittedly, communicating arguments among various scripts is getting cumbersome. E.g. if you want to use `--without-hsl` in the docker build script, you need to pass arguments for the repo URL and branch, even if you just want to use default options. Maybe environment variables would be a better choice here, although I tend to prefer explicit command line arguments.