### PR TITLE
Compile Mumps without Metis

### DIFF
--- a/scripts/compile_solvers.sh
+++ b/scripts/compile_solvers.sh
@@ -197,7 +197,11 @@ echo "#########################################################################"
 echo "# Thirdparty/Mumps                                                      #"
 echo "#########################################################################"
 cd ThirdParty/Mumps
-./configure --disable-shared --enable-static --with-metis \
+# We compile without metis to get around a suspected Metis/Mumps version
+# incompatibility. See https://github.com/IDAES/idaes-ext/issues/268
+# ThirdParty/Metis uses v4.0.3, while ThirdParty/Mumps uses the latest release.
+METISFLAG="--without-metis"
+./configure --disable-shared --enable-static $METISFLAG \
  --prefix=$IDAES_EXT/coinbrew/dist FFLAGS="-fPIC" CFLAGS="-fPIC" CXXFLAGS="-fPIC"
 make $PARALLEL
 make install


### PR DESCRIPTION
This addresses part of #268. A better solution would be to figure out the version incompatibility, and compile Mumps with the latest version of Metis, e.g. from http://glaros.dtc.umn.edu/gkhome/metis/metis/download. However, since I don't think many people use Mumps with Metis, for the sake of getting something working without refactoring multiple parts of our build script, I propose we just tell Mumps not to use Metis for now.